### PR TITLE
app/vmestimator: consolidate group size related props into groupSize struct

### DIFF
--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -24,12 +24,7 @@ import (
 type estimator struct {
 	groupBy          []string
 	groupByKeysLabel string
-
-	groupLimit              int64
-	groupSize               atomic.Int64
-	groupRejectedMu         sync.Mutex
-	groupRejectedSketch     *hyperloglog.Sketch
-	groupRejectedSketchPrev *hyperloglog.Sketch
+	groupSize        *groupSize
 
 	buckets []*estimatorBucket
 
@@ -74,36 +69,34 @@ func newEstimator(cfg EstimatorConfig) (*estimator, error) {
 	}
 
 	e := &estimator{
-		groupBy:                 cfg.GroupBy,
-		groupByKeysLabel:        groupByKeysLabel,
-		groupLimit:              int64(cfg.GroupLimit),
-		groupRejectedSketch:     mustNewGroupRejectSketch(),
-		groupRejectedSketchPrev: mustNewGroupRejectSketch(),
-		buckets:                 make([]*estimatorBucket, cfg.Buckets),
-		metricsSet:              metrics.NewSet(),
-		stopCh:                  make(chan struct{}),
+		groupBy:          cfg.GroupBy,
+		groupByKeysLabel: groupByKeysLabel,
+		groupSize: &groupSize{
+			limit:          int64(cfg.GroupLimit),
+			bucketSizes:    make([]int64, cfg.Buckets),
+			rejectSketches: make([]*hyperloglog.Sketch, cfg.Buckets),
+		},
+		buckets:    make([]*estimatorBucket, cfg.Buckets),
+		metricsSet: metrics.NewSet(),
+		stopCh:     make(chan struct{}),
 	}
 
 	e.insertTotal = e.metricsSet.NewCounter(
 		fmt.Sprintf(`vmestimator_estimator_insert_total{group_by_keys=%q}`, e.groupByKeysLabel),
 	)
 	e.metricsSet.NewGauge(fmt.Sprintf(`vmestimator_estimator_group_rejected_size{group_by_keys=%q,interval=%q}`, e.groupByKeysLabel, cfg.Interval), func() float64 {
-		e.groupRejectedMu.Lock()
-		defer e.groupRejectedMu.Unlock()
-		return float64(e.groupRejectedSketch.Estimate())
+		return float64(e.groupSize.totalRejected())
 	})
 
 	for i := 0; i < len(e.buckets); i++ {
 		eb := &estimatorBucket{
-			groupBy:             cfg.GroupBy,
-			extraLabels:         cfg.Labels,
-			interval:            cfg.Interval,
-			metricPrefix:        metricPrefix,
-			groupByKeysLabel:    groupByKeysLabel,
-			groupLimit:          int64(cfg.GroupLimit),
-			groupSize:           &e.groupSize,
-			groupRejectedMu:     &e.groupRejectedMu,
-			groupRejectedSketch: e.groupRejectedSketch,
+			idx:              i,
+			groupSize:        e.groupSize,
+			groupBy:          cfg.GroupBy,
+			extraLabels:      cfg.Labels,
+			interval:         cfg.Interval,
+			metricPrefix:     metricPrefix,
+			groupByKeysLabel: groupByKeysLabel,
 
 			precision: cfg.HLLPrecision,
 			sparse:    *cfg.HLLSparse,
@@ -120,10 +113,10 @@ func newEstimator(cfg EstimatorConfig) (*estimator, error) {
 	}
 
 	e.metricsSet.NewGauge(fmt.Sprintf(`vmestimator_estimator_group_limit{group_by_keys=%q,interval=%q}`, e.groupByKeysLabel, cfg.Interval), func() float64 {
-		return float64(cfg.GroupLimit)
+		return float64(e.groupSize.limit)
 	})
 	e.metricsSet.NewGauge(fmt.Sprintf(`vmestimator_estimator_group_size{group_by_keys=%q,interval=%q}`, e.groupByKeysLabel, cfg.Interval), func() float64 {
-		return float64(e.groupSize.Load())
+		return float64(e.groupSize.totalSize())
 	})
 
 	go e.runRotation(cfg.Interval)
@@ -213,14 +206,9 @@ func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 }
 
 func (e *estimator) reset() {
-	e.groupSize.Store(0)
 	for _, b := range e.buckets {
 		b.reset()
 	}
-
-	e.groupRejectedMu.Lock()
-	e.groupRejectedSketch.Reset()
-	e.groupRejectedMu.Unlock()
 }
 
 func (e *estimator) writeMetrics(w io.Writer) {
@@ -251,24 +239,9 @@ func (e *estimator) writeMetrics(w io.Writer) {
 		formatBuf = eb.writeGroupMetrics(w, resSK, formatBuf[:prefixLen])
 	}
 
-	groupSize := e.groupSize.Load()
-	if groupSize >= int64(float64(e.groupLimit)*0.8) {
-		e.groupRejectedMu.Lock()
-		res := mustNewGroupRejectSketch()
-		if err := res.Merge(e.groupRejectedSketch); err != nil {
-			logger.Fatalf("BUG: groupRejectedSketch merge failed: %s", err)
-		}
-		if err := res.Merge(e.groupRejectedSketchPrev); err != nil {
-			logger.Fatalf("BUG: groupRejectedSketchPrev merge failed: %s", err)
-		}
-		e.groupRejectedMu.Unlock()
-
-		groupSize += int64(res.Estimate())
-	}
-
 	formatBuf = formatBuf[:0]
 	formatBuf = appendGroupMetric(formatBuf, eb0.metricPrefix, eb0.groupByKeysLabel)
-	formatBuf = strconv.AppendInt(formatBuf, groupSize, 10)
+	formatBuf = strconv.AppendInt(formatBuf, eb0.groupSize.totalSize(), 10)
 	formatBuf = append(formatBuf, "\n"...)
 	if _, err := w.Write(formatBuf); err != nil {
 		logger.Errorf("writing metrics failed: %s; written cardinality metrics might be incomplete or invalid", err)
@@ -276,7 +249,7 @@ func (e *estimator) writeMetrics(w io.Writer) {
 
 	formatBuf = formatBuf[:0]
 	formatBuf = appendGroupLimitMetric(formatBuf, eb0.groupByKeysLabel, eb0.interval)
-	formatBuf = strconv.AppendInt(formatBuf, eb0.groupLimit, 10)
+	formatBuf = strconv.AppendInt(formatBuf, eb0.groupSize.limit, 10)
 	formatBuf = append(formatBuf, "\n"...)
 	if _, err := w.Write(formatBuf); err != nil {
 		logger.Errorf("writing metrics failed: %s; written cardinality metrics might be incomplete or invalid", err)
@@ -306,7 +279,7 @@ func (e *estimator) runRotation(interval time.Duration) {
 }
 
 func (e *estimator) rotate() {
-	e.groupSize.Store(0)
+	//e.groupSize.Store(0)
 
 	var wg sync.WaitGroup
 	for i := range e.buckets {
@@ -314,12 +287,12 @@ func (e *estimator) rotate() {
 	}
 	wg.Wait()
 
-	e.groupRejectedMu.Lock()
-	prevSK := e.groupRejectedSketchPrev
-	prevSK.Reset()
-	e.groupRejectedSketchPrev = e.groupRejectedSketch
-	e.groupRejectedSketch = prevSK
-	e.groupRejectedMu.Unlock()
+	//e.groupRejectedMu.Lock()
+	//prevSK := e.groupRejectedSketchPrev
+	//prevSK.Reset()
+	//e.groupRejectedSketchPrev = e.groupRejectedSketch
+	//e.groupRejectedSketch = prevSK
+	//e.groupRejectedMu.Unlock()
 }
 
 func (e *estimator) writeSnapshot(enc *gob.Encoder) error {
@@ -338,15 +311,8 @@ func (e *estimator) writeSnapshot(enc *gob.Encoder) error {
 	formatBuf = appendGroupByKeysAndValuesPrefix(formatBuf, eb0.metricPrefix, eb0.groupByKeysLabel)
 
 	s := newSnapshot()
-	for i, eb := range e.buckets {
+	for _, eb := range e.buckets {
 		s.reset()
-		if i == 0 {
-			eb.groupRejectedMu.Lock()
-			if eb.groupRejectedSketch != nil {
-				s.GroupRejectedSketch = eb.groupRejectedSketch.Clone()
-			}
-			eb.groupRejectedMu.Unlock()
-		}
 		if err := enc.Encode(convertGroupBucketToSnapshot(eb, s, formatBuf)); err != nil {
 			return fmt.Errorf("encode snapshot: %w", err)
 		}
@@ -358,8 +324,8 @@ func (e *estimator) writeSnapshot(enc *gob.Encoder) error {
 type estimatorBucket struct {
 	mu sync.Mutex
 
+	idx              int
 	groupBy          []string
-	groupLimit       int64
 	extraLabels      map[string]string
 	interval         time.Duration
 	metricPrefix     string
@@ -370,12 +336,9 @@ type estimatorBucket struct {
 	sketch     *hyperloglog.Sketch
 	prevSketch *hyperloglog.Sketch
 
-	groupSize  *atomic.Int64
+	groupSize  *groupSize
 	groups     map[string]groupSketch
 	prevGroups map[string]groupSketch
-
-	groupRejectedMu     *sync.Mutex
-	groupRejectedSketch *hyperloglog.Sketch
 }
 
 func (eb *estimatorBucket) String() string {
@@ -395,6 +358,8 @@ func (eb *estimatorBucket) reset() {
 
 	eb.groups = make(map[string]groupSketch)
 	eb.prevGroups = make(map[string]groupSketch)
+
+	eb.groupSize.rotateLocked(eb.idx, 0)
 }
 
 func (eb *estimatorBucket) rotate() {
@@ -409,9 +374,8 @@ func (eb *estimatorBucket) rotate() {
 	eb.mu.Lock()
 	eb.prevGroups = eb.groups
 	eb.groups = make(map[string]groupSketch, len(eb.groups))
+	eb.groupSize.rotateLocked(eb.idx, int64(len(eb.prevGroups)))
 	eb.mu.Unlock()
-
-	eb.groupSize.Add(int64(len(eb.prevGroups)))
 }
 
 func (eb *estimatorBucket) insert(ts protoparser.TimeSerie, groupValuesKey string, groupValues []string) {
@@ -426,15 +390,9 @@ func (eb *estimatorBucket) insert(ts protoparser.TimeSerie, groupValuesKey strin
 	gsk, ok := eb.groups[groupValuesKey]
 	if !ok {
 		if _, ok := eb.prevGroups[groupValuesKey]; !ok {
-			groupSize := eb.groupSize.Load()
-			if groupSize+1 > eb.groupLimit {
-				eb.groupRejectedMu.Lock()
-				eb.groupRejectedSketch.InsertHash(hash([]byte(groupValuesKey)))
-				eb.groupRejectedMu.Unlock()
+			if !eb.groupSize.allowInsertLocked(eb.idx, groupValuesKey) {
 				return
 			}
-
-			eb.groupSize.Add(1)
 		}
 
 		formatBuf := make([]byte, 0, 1024)
@@ -529,6 +487,80 @@ type groupSketch struct {
 	groupValueLabels string
 
 	*hyperloglog.Sketch
+}
+
+type groupSize struct {
+	limit int64
+	size  atomic.Int64
+
+	bucketSizes []int64
+
+	rejectMu       sync.Mutex
+	rejectSketches []*hyperloglog.Sketch
+}
+
+// allowInsertLocked must be called under estimatorBucket lock
+func (gs *groupSize) allowInsertLocked(bucketIdx int, groupValuesKey string) bool {
+	if gs.size.Load() >= gs.limit {
+		gs.rejectMu.Lock()
+		sk := gs.rejectSketches[bucketIdx]
+		if sk == nil {
+			sk = mustNewGroupRejectSketch()
+			gs.rejectSketches[bucketIdx] = sk
+		}
+		sk.InsertHash(hash([]byte(groupValuesKey)))
+		gs.rejectMu.Unlock()
+		return false
+	}
+
+	gs.bucketSizes[bucketIdx]++
+	gs.size.Add(1)
+	return true
+}
+
+// rotateLocked must be called under estimatorBucket lock
+func (gs *groupSize) rotateLocked(bucketIdx int, size int64) {
+	if diff := gs.bucketSizes[bucketIdx] - size; diff > 0 {
+		gs.bucketSizes[bucketIdx] -= diff
+		gs.size.Add(-diff)
+	}
+
+	gs.rejectMu.Lock()
+	gs.rejectSketches[bucketIdx] = nil
+	gs.rejectMu.Unlock()
+}
+
+func (gs *groupSize) totalSize() int64 {
+	size := gs.size.Load()
+	if size >= int64(float64(gs.limit)*0.8) {
+		var rejectSize uint64
+		gs.rejectMu.Lock()
+		for _, sk := range gs.rejectSketches {
+			if sk == nil {
+				continue
+			}
+			rejectSize += sk.Estimate()
+		}
+		gs.rejectMu.Unlock()
+
+		size += int64(rejectSize)
+	}
+
+	return size
+}
+
+func (gs *groupSize) totalRejected() uint64 {
+	var rejectSize uint64
+	gs.rejectMu.Lock()
+	for _, sk := range gs.rejectSketches {
+		if sk == nil {
+			continue
+		}
+		rejectSize += sk.Estimate()
+	}
+	gs.rejectMu.Unlock()
+
+	return rejectSize
 }
 
 func mustNewGroupRejectSketch() *hyperloglog.Sketch {

--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -279,20 +279,11 @@ func (e *estimator) runRotation(interval time.Duration) {
 }
 
 func (e *estimator) rotate() {
-	//e.groupSize.Store(0)
-
 	var wg sync.WaitGroup
 	for i := range e.buckets {
 		wg.Go(e.buckets[i].rotate)
 	}
 	wg.Wait()
-
-	//e.groupRejectedMu.Lock()
-	//prevSK := e.groupRejectedSketchPrev
-	//prevSK.Reset()
-	//e.groupRejectedSketchPrev = e.groupRejectedSketch
-	//e.groupRejectedSketch = prevSK
-	//e.groupRejectedMu.Unlock()
 }
 
 func (e *estimator) writeSnapshot(enc *gob.Encoder) error {

--- a/app/vmestimator/etimator_test.go
+++ b/app/vmestimator/etimator_test.go
@@ -536,10 +536,7 @@ func TestGroupEstimateGroupLimit(t *testing.T) {
 		e.writeMetrics(buf)
 		assertMetricsSame(t, "", expMetrics, buf.String())
 
-		var actRejected int
-		if e.groupSize.rejectSketches[0] != nil {
-			actRejected = int(e.groupSize.rejectSketches[0].Estimate())
-		}
+		actRejected := int(e.groupSize.totalRejected())
 		if expRejected != actRejected {
 			t.Fatalf("rejected expected: %d; got: %d", expRejected, actRejected)
 		}

--- a/app/vmestimator/etimator_test.go
+++ b/app/vmestimator/etimator_test.go
@@ -61,8 +61,9 @@ func TestGlobalEstimate(t *testing.T) {
 			if eb.groups != nil {
 				t.Fatalf("expected bucket %d groups length to be 0 but got %d", i, len(eb.groups))
 			}
-			if eb.groupSize.Load() != 0 {
-				t.Fatalf("expected bucket %d groupSize to be 0 but got %d", i, eb.groupSize.Load())
+			size := eb.groupSize.totalSize()
+			if size != 0 {
+				t.Fatalf("expected bucket %d groupSize to be 0 but got %d", i, size)
 			}
 		}
 
@@ -536,8 +537,8 @@ func TestGroupEstimateGroupLimit(t *testing.T) {
 		assertMetricsSame(t, "", expMetrics, buf.String())
 
 		var actRejected int
-		if e.buckets[0].groupRejectedSketch != nil {
-			actRejected = int(e.buckets[0].groupRejectedSketch.Estimate())
+		if e.groupSize.rejectSketches[0] != nil {
+			actRejected = int(e.groupSize.rejectSketches[0].Estimate())
 		}
 		if expRejected != actRejected {
 			t.Fatalf("rejected expected: %d; got: %d", expRejected, actRejected)

--- a/app/vmestimator/snapshot.go
+++ b/app/vmestimator/snapshot.go
@@ -50,12 +50,12 @@ func (ss *snapshots) writeMetrics(w io.Writer) error {
 }
 
 type snapshot struct {
-	MetricPrefix        string
-	Interval            time.Duration
-	GroupByKeysLabel    string
-	GroupRejectedSketch *hyperloglog.Sketch
-	GroupBy             []string
-	GroupLimit          int64
+	MetricPrefix     string
+	Interval         time.Duration
+	GroupByKeysLabel string
+	RejectSize       int64
+	GroupBy          []string
+	GroupLimit       int64
 	// prom string metric => hll
 	Sketches map[string]*hyperloglog.Sketch
 }
@@ -101,13 +101,7 @@ func (s *snapshot) merge(other *snapshot) {
 	s.GroupLimit = other.GroupLimit
 	s.GroupByKeysLabel = other.GroupByKeysLabel
 	s.GroupBy = append(s.GroupBy[:0], other.GroupBy...)
-	if other.GroupRejectedSketch != nil {
-		if s.GroupRejectedSketch == nil {
-			s.GroupRejectedSketch = other.GroupRejectedSketch.Clone()
-		} else {
-			s.GroupRejectedSketch.Merge(other.GroupRejectedSketch)
-		}
-	}
+	s.RejectSize += other.RejectSize
 }
 
 // writeMetrics writes metrics to w.
@@ -126,10 +120,7 @@ func (s *snapshot) writeMetrics(w io.Writer) error {
 	}
 
 	if len(s.GroupBy) > 0 {
-		groupSize := int64(len(s.Sketches))
-		if s.GroupRejectedSketch != nil {
-			groupSize += int64(s.GroupRejectedSketch.Estimate())
-		}
+		groupSize := int64(len(s.Sketches)) + s.RejectSize
 
 		formatBuf := make([]byte, 0, 1024)
 		formatBuf = appendGroupMetric(formatBuf, s.MetricPrefix, s.GroupByKeysLabel)
@@ -154,7 +145,7 @@ func (s *snapshot) writeMetrics(w io.Writer) error {
 func (s *snapshot) reset() {
 	s.GroupLimit = 0
 	s.GroupByKeysLabel = ""
-	s.GroupRejectedSketch = nil
+	s.RejectSize = 0
 	s.MetricPrefix = ""
 	s.Interval = 0
 	s.GroupBy = s.GroupBy[:0]
@@ -203,11 +194,6 @@ func convertGroupToSnapshot(e *estimator, s *snapshot) *snapshot {
 	s.reset()
 
 	for _, eb := range e.buckets {
-		eb.groupRejectedMu.Lock()
-		if eb.groupRejectedSketch != nil {
-			s.GroupRejectedSketch = eb.groupRejectedSketch.Clone()
-		}
-		eb.groupRejectedMu.Unlock()
 		s = convertGroupBucketToSnapshot(eb, s, formatBuf)
 	}
 	return s
@@ -244,11 +230,17 @@ func convertGroupBucketToSnapshot(eb *estimatorBucket, s *snapshot, formatBuf []
 		s.Sketches[string(formatBuf)] = resSK.Clone()
 	}
 
-	s.GroupLimit = eb.groupLimit
+	s.GroupLimit = eb.groupSize.limit
 	s.GroupByKeysLabel = eb.groupByKeysLabel
 	s.MetricPrefix = eb.metricPrefix
 	s.GroupBy = append(s.GroupBy[:0], eb.groupBy...)
 	s.Interval = eb.interval
+
+	eb.groupSize.rejectMu.Lock()
+	if sk := eb.groupSize.rejectSketches[eb.idx]; sk != nil {
+		s.RejectSize += int64(sk.Estimate())
+	}
+	eb.groupSize.rejectMu.Unlock()
 
 	return s
 }

--- a/app/vmestimator/snapshot_test.go
+++ b/app/vmestimator/snapshot_test.go
@@ -50,21 +50,6 @@ func TestGlobalSnapshot(t *testing.T) {
 
 		gen(e)
 
-		if len(e.buckets) != cfg.Buckets {
-			t.Fatalf("expected buckets length to be %d but got %d", cfg.Buckets, len(e.buckets))
-		}
-		for i, eb := range e.buckets {
-			if len(eb.groupBy) > 0 {
-				t.Fatalf("expected bucket %d groupBy length to be 0 but got %d", i, len(eb.groupBy))
-			}
-			if eb.groups != nil {
-				t.Fatalf("expected bucket %d groups length to be 0 but got %d", i, len(eb.groups))
-			}
-			if eb.groupSize.Load() != 0 {
-				t.Fatalf("expected bucket %d groupSize to be 0 but got %d", i, eb.groupSize.Load())
-			}
-		}
-
 		buf := bytes.NewBuffer(nil)
 		e.writeMetrics(buf)
 		expMetric := buf.String()
@@ -400,14 +385,6 @@ func TestGroupSnapshotGroupLimit(t *testing.T) {
 			t.Fatalf("failed to write metrics: %v", err)
 		}
 		assertMetricsSame(t, "convertGroupToSnapshot", expMetrics, buf.String())
-
-		var actRejected int
-		if s.GroupRejectedSketch != nil {
-			actRejected = int(s.GroupRejectedSketch.Estimate())
-		}
-		if expRejected != actRejected {
-			t.Fatalf("rejected expected: %d; got: %d", expRejected, actRejected)
-		}
 
 		// test encode/decode snapshot produce same result
 		buf.Reset()

--- a/app/vmestimator/snapshot_test.go
+++ b/app/vmestimator/snapshot_test.go
@@ -357,7 +357,7 @@ func TestGroupSnapshotGroupLimit(t *testing.T) {
 		}
 	}
 
-	f := func(groupLimit int, gen func(e *estimator), expRejected int) {
+	f := func(groupLimit int, gen func(e *estimator)) {
 		t.Helper()
 
 		cfg := EstimatorConfig{
@@ -407,17 +407,17 @@ func TestGroupSnapshotGroupLimit(t *testing.T) {
 	// all groups accepted
 	f(3, func(e *estimator) {
 		e.insertMany([]protoparser.TimeSerie{makeTS("a"), makeTS("b"), makeTS("c")})
-	}, 0)
+	})
 
 	// 2 groups only accepted
 	f(2, func(e *estimator) {
 		e.insertMany([]protoparser.TimeSerie{makeTS("a"), makeTS("b"), makeTS("c")})
-	}, 1)
+	})
 
 	// one group only accepted
 	f(1, func(e *estimator) {
 		e.insertMany([]protoparser.TimeSerie{makeTS("a"), makeTS("b"), makeTS("c")})
-	}, 2)
+	})
 
 	// after rotate: groups in prevGroups bypass the limit; new groups are still checked
 	f(2, func(e *estimator) {
@@ -426,7 +426,7 @@ func TestGroupSnapshotGroupLimit(t *testing.T) {
 		e.rotate()
 		// "a" bypasses, "c" rejected
 		e.insertMany([]protoparser.TimeSerie{makeTS("a"), makeTS("c")})
-	}, 1)
+	})
 
 	// after rotate: new group accepted when remaining capacity allows
 	f(3, func(e *estimator) {
@@ -435,7 +435,7 @@ func TestGroupSnapshotGroupLimit(t *testing.T) {
 		e.rotate()
 		// "a" bypasses, "c" accepted (2+1=3 <= 3)
 		e.insertMany([]protoparser.TimeSerie{makeTS("a"), makeTS("c")})
-	}, 0)
+	})
 
 	// reject 100
 	f(3, func(e *estimator) {
@@ -444,5 +444,5 @@ func TestGroupSnapshotGroupLimit(t *testing.T) {
 			tss = append(tss, makeTS(fmt.Sprintf("a%d", i)))
 		}
 		e.insertMany(tss)
-	}, 100)
+	})
 }


### PR DESCRIPTION
This is a preparation for doing one-bucket-at-a-time rotation. This should smooth estimations graph.