### PR TITLE
app/vmestimator: reuse prev groupValueLabels metric part

### DIFF
--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -425,7 +425,8 @@ func (eb *estimatorBucket) insert(ts protoparser.TimeSerie, groupValuesKey strin
 
 	gsk, ok := eb.groups[groupValuesKey]
 	if !ok {
-		if _, ok := eb.prevGroups[groupValuesKey]; !ok {
+		prevGSK, ok := eb.prevGroups[groupValuesKey]
+		if !ok {
 			groupSize := eb.groupSize.Load()
 			if groupSize+1 > eb.groupLimit {
 				eb.groupRejectedMu.Lock()
@@ -433,27 +434,31 @@ func (eb *estimatorBucket) insert(ts protoparser.TimeSerie, groupValuesKey strin
 				eb.groupRejectedMu.Unlock()
 				return
 			}
-
 			eb.groupSize.Add(1)
 		}
 
-		formatBuf := make([]byte, 0, 1024)
-		formatBuf = strconv.AppendQuote(formatBuf, groupValuesKey)
-		for i := range groupValues {
-			formatBuf = append(formatBuf, ',')
-			if eb.groupBy[i] == `__name__` {
-				formatBuf = append(formatBuf, `by__name__`...)
-			} else {
-				formatBuf = append(formatBuf, `by_`...)
-				formatBuf = append(formatBuf, eb.groupBy[i]...)
+		groupValueLabels := prevGSK.groupValueLabels
+		if len(groupValueLabels) == 0 {
+			formatBuf := make([]byte, 0, 1024)
+			formatBuf = strconv.AppendQuote(formatBuf, groupValuesKey)
+			for i := range groupValues {
+				formatBuf = append(formatBuf, ',')
+				if eb.groupBy[i] == `__name__` {
+					formatBuf = append(formatBuf, `by__name__`...)
+				} else {
+					formatBuf = append(formatBuf, `by_`...)
+					formatBuf = append(formatBuf, eb.groupBy[i]...)
+				}
+				formatBuf = append(formatBuf, '=')
+				formatBuf = strconv.AppendQuote(formatBuf, groupValues[i])
 			}
-			formatBuf = append(formatBuf, '=')
-			formatBuf = strconv.AppendQuote(formatBuf, groupValues[i])
+			formatBuf = append(formatBuf, `} `...)
+
+			groupValueLabels = bytesutil.ToUnsafeString(formatBuf)
 		}
-		formatBuf = append(formatBuf, `} `...)
 
 		gsk = groupSketch{
-			groupValueLabels: bytesutil.ToUnsafeString(formatBuf),
+			groupValueLabels: groupValueLabels,
 
 			Sketch: eb.newSketch(),
 		}


### PR DESCRIPTION
releveant benchstat

pkg: github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser

│ baseline.bench │   reuse-group-value-labels.bench   │

│     sec/op     │   sec/op     vs base               │
Parse-10
3.997m ± 1%   3.848m ± 1%  -3.73% (p=0.001 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=0/LabelSize=0/GroupBy=3-10
224.4µ ± 0%   222.8µ ± 2%       ~ (p=0.052 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=1/LabelSize=20/GroupBy=3-10
407.1µ ± 1%   378.0µ ± 1%  -7.14% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=20/GroupBy=3-10
601.9µ ± 0%   576.3µ ± 0%  -4.27% (p=0.002 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=20/LabelSize=20/GroupBy=3-10
3.014m ± 1%   2.887m ± 3%  -4.24% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=10000/Labels=20/LabelSize=20/GroupBy=3-10
6.029m ± 0%   5.766m ± 1%  -4.37% (p=0.001 n=10)
WriteRequest_UnmarshalProtobuf/Rows=20000/Labels=20/LabelSize=20/GroupBy=3-10
12.04m ± 0%   11.58m ± 3%  -3.77% (p=0.002 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=2000/GroupBy=3-10
4.106m ± 1%   4.260m ± 1%  +3.76% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=2000/LabelSize=100/GroupBy=3-10
67.98m ± 0%   66.96m ± 0%  -1.50% (p=0.000 n=10)
geomean
2.875m        2.791m       -2.93%

│ baseline.bench │   reuse-group-value-labels.bench    │

│      B/s       │     B/s       vs base               │
Parse-10
117.1Mi ± 1%   121.6Mi ± 1%  +3.88% (p=0.001 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=0/LabelSize=0/GroupBy=3-10
701.1Mi ± 0%   706.3Mi ± 2%       ~ (p=0.052 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=1/LabelSize=20/GroupBy=3-10
878.6Mi ± 1%   946.1Mi ± 1%  +7.69% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=20/GroupBy=3-10
1.352Gi ± 0%   1.413Gi ± 0%  +4.46% (p=0.002 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=20/LabelSize=20/GroupBy=3-10
1.350Gi ± 1%   1.410Gi ± 3%  +4.42% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=10000/Labels=20/LabelSize=20/GroupBy=3-10
1.350Gi ± 0%   1.412Gi ± 1%  +4.57% (p=0.001 n=10)
WriteRequest_UnmarshalProtobuf/Rows=20000/Labels=20/LabelSize=20/GroupBy=3-10
1.353Gi ± 0%   1.405Gi ± 3%  +3.91% (p=0.002 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=2000/GroupBy=3-10
9.190Gi ± 1%   8.856Gi ± 1%  -3.63% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=2000/LabelSize=100/GroupBy=3-10
3.383Gi ± 0%   3.435Gi ± 0%  +1.52% (p=0.000 n=10)
geomean
1.241Gi        1.278Gi       +3.02%