### PR TITLE
app/vmestimator: randomize estimator iteration order to reduce lock contention

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ Here are some resources and information about vmestimator:
 - [Documentation](https://docs.victoriametrics.com/victoriametrics/vmestimator/)
 - Available: [Binary releases](https://github.com/VictoriaMetrics/vmestimator/releases/latest), docker images [Docker Hub](https://hub.docker.com/r/victoriametrics/vmestimator/) and [Quay](https://quay.io/repository/victoriametrics/victoria-traces), [Source code](https://github.com/VictoriaMetrics/vmestimator)
 - Deployment types: [Single-node version](https://docs.victoriametrics.com/victoriametrics/vmestimator/#design), [Cluster version](https://docs.victoriametrics.com/victoriametrics/vmestimator/#cluster)
-<!-- 
-TODO - Changelog: [CHANGELOG](https://docs.victoriametrics.com/victoriametrics/vmestimator/changelog/)
--->
+- Changelog: [CHANGELOG](https://github.com/VictoriaMetrics/vmestimator/tree/main/docs/vmestimator)
 - Community: [Slack](https://slack.victoriametrics.com/), [X (Twitter)](https://x.com/VictoriaMetrics), [LinkedIn](https://www.linkedin.com/company/victoriametrics/), [YouTube](https://www.youtube.com/@VictoriaMetrics)
 
 Both the single-node and the cluster versions of vmestimator are open source and free to use.

--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -156,7 +156,7 @@ func putGroupValuesSlice(key *[]byte) {
 
 func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 	bucketsNum := uint64(len(e.buckets))
-	var cnt int
+
 	if len(e.groupBy) == 0 {
 		tssLen := uint32(len(tss))
 		start := fastrand.Uint32n(tssLen)
@@ -166,12 +166,12 @@ func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 			ts := tss[i]
 			bi := int(ts.Fingerprint % bucketsNum)
 			e.buckets[bi].insert(ts, "", nil)
-			cnt++
-			continue
 		}
-		e.insertTotal.Add(cnt)
+		e.insertTotal.Add(len(tss))
+		return
 	}
 
+	var cnt int
 	groupValuesKeyP := getGroupValuesKeySlice()
 	groupValuesKey := *groupValuesKeyP
 	defer func() {

--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -11,13 +11,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/axiomhq/hyperloglog"
+	"github.com/dgryski/go-metro"
+	"github.com/valyala/fastrand"
+
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/metrics"
-	"github.com/axiomhq/hyperloglog"
-	"github.com/dgryski/go-metro"
-
 	"github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser"
 )
 
@@ -155,6 +156,21 @@ func putGroupValuesSlice(key *[]byte) {
 
 func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 	bucketsNum := uint64(len(e.buckets))
+	var cnt int
+	if len(e.groupBy) == 0 {
+		tssLen := uint32(len(tss))
+		start := fastrand.Uint32n(tssLen)
+		for j := uint32(0); j < tssLen; j++ {
+			i := (start + j) % tssLen
+
+			ts := tss[i]
+			bi := int(ts.Fingerprint % bucketsNum)
+			e.buckets[bi].insert(ts, "", nil)
+			cnt++
+			continue
+		}
+		e.insertTotal.Add(cnt)
+	}
 
 	groupValuesKeyP := getGroupValuesKeySlice()
 	groupValuesKey := *groupValuesKeyP
@@ -165,14 +181,12 @@ func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 
 	groupValues := make([]string, len(e.groupBy))
 
-	var cnt int
-	for _, ts := range tss {
-		if len(e.groupBy) == 0 {
-			i := int(ts.Fingerprint % bucketsNum)
-			e.buckets[i].insert(ts, "", nil)
-			cnt++
-			continue
-		}
+	tssLen := uint32(len(tss))
+	start := fastrand.Uint32n(tssLen)
+	for j := uint32(0); j < tssLen; j++ {
+		i := (start + j) % tssLen
+
+		ts := tss[i]
 
 		groupValuesKey = groupValuesKey[:0]
 		clear(groupValues)
@@ -198,8 +212,8 @@ func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 			continue
 		}
 
-		i := int(hash(groupValuesKey) % bucketsNum)
-		e.buckets[i].insert(ts, bytesutil.ToUnsafeString(groupValuesKey), groupValues)
+		bi := int(hash(groupValuesKey) % bucketsNum)
+		e.buckets[bi].insert(ts, bytesutil.ToUnsafeString(groupValuesKey), groupValues)
 		cnt++
 	}
 

--- a/app/vmestimator/etimator_test.go
+++ b/app/vmestimator/etimator_test.go
@@ -544,7 +544,7 @@ func TestGroupEstimateGroupLimit(t *testing.T) {
 		}
 	}
 
-	f := func(groupLimit int, gen func(e *estimator), expRejected int, expMetrics string) {
+	f := func(groupLimit int, gen func(e *estimator), expRejected, expTotalSize int) {
 		t.Helper()
 
 		cfg := EstimatorConfig{
@@ -564,42 +564,33 @@ func TestGroupEstimateGroupLimit(t *testing.T) {
 
 		buf := bytes.NewBuffer(nil)
 		e.writeMetrics(buf)
-		assertMetricsSame(t, "", expMetrics, buf.String())
 
 		actRejected := int(e.groupSize.totalRejected())
 		if expRejected != actRejected {
 			t.Fatalf("rejected expected: %d; got: %d", expRejected, actRejected)
+		}
+		actTotalSize := int(e.groupSize.totalSize())
+		if expTotalSize != actTotalSize {
+			t.Fatalf("total size expected: %d; got: %d", expTotalSize, actTotalSize)
 		}
 	}
 
 	// all groups accepted
 	f(3, func(e *estimator) {
 		e.insertMany([]protoparser.TimeSerie{makeTS("a"), makeTS("b"), makeTS("c")})
-	}, 0, `
-cardinality_estimate{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 3
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="a",by_foo="a"} 1
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="b",by_foo="b"} 1
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="c",by_foo="c"} 1
-vmestimator_estimator_group_limit{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 3`,
+	}, 0, 3,
 	)
 
 	// 2 groups only accepted
 	f(2, func(e *estimator) {
 		e.insertMany([]protoparser.TimeSerie{makeTS("a"), makeTS("b"), makeTS("c")})
-	}, 1, `
-cardinality_estimate{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 3
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="a",by_foo="a"} 1
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="b",by_foo="b"} 1
-vmestimator_estimator_group_limit{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 2`,
+	}, 1, 3,
 	)
 
 	// one group only accepted
 	f(1, func(e *estimator) {
 		e.insertMany([]protoparser.TimeSerie{makeTS("a"), makeTS("b"), makeTS("c")})
-	}, 2, `
-cardinality_estimate{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 3
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="a",by_foo="a"} 1
-vmestimator_estimator_group_limit{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 1`,
+	}, 2, 3,
 	)
 
 	// after rotate: groups in prevGroups bypass the limit; new groups are still checked
@@ -611,11 +602,7 @@ vmestimator_estimator_group_limit{interval="10m0s",group_by_keys="__group__",gro
 		}
 		// "a" bypasses, "c" rejected
 		e.insertMany([]protoparser.TimeSerie{makeTS("a"), makeTS("c")})
-	}, 1, `
-cardinality_estimate{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 3
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="a",by_foo="a"} 1
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="b",by_foo="b"} 1
-vmestimator_estimator_group_limit{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 2`,
+	}, 1, 3,
 	)
 
 	// after rotate: new group accepted when remaining capacity allows
@@ -627,12 +614,7 @@ vmestimator_estimator_group_limit{interval="10m0s",group_by_keys="__group__",gro
 		}
 		// "a" bypasses, "c" accepted (2+1=3 <= 3)
 		e.insertMany([]protoparser.TimeSerie{makeTS("a"), makeTS("c")})
-	}, 0, `
-cardinality_estimate{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 3
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="a",by_foo="a"} 1
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="b",by_foo="b"} 1
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="c",by_foo="c"} 1
-vmestimator_estimator_group_limit{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 3`,
+	}, 0, 3,
 	)
 
 	// reject 100
@@ -642,12 +624,7 @@ vmestimator_estimator_group_limit{interval="10m0s",group_by_keys="__group__",gro
 			tss = append(tss, makeTS(fmt.Sprintf("a%d", i)))
 		}
 		e.insertMany(tss)
-	}, 100, `
-cardinality_estimate{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 103
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="a0",by_foo="a0"} 1
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="a1",by_foo="a1"} 1
-cardinality_estimate{interval="10m0s",group_by_keys="foo",group_by_values="a2",by_foo="a2"} 1
-vmestimator_estimator_group_limit{interval="10m0s",group_by_keys="__group__",group_by_values="foo"} 3`,
+	}, 100, 103,
 	)
 }
 

--- a/app/vmestimator/main.go
+++ b/app/vmestimator/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/pushmetrics"
 	"github.com/VictoriaMetrics/metrics"
 	"github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser"
+	"github.com/valyala/fastrand"
 )
 
 var (
@@ -80,8 +81,11 @@ func main() {
 		case "/api/v1/write":
 			prometheusWriteRequests.Inc()
 			err := protoparser.Parse(r.Body, groupLabels, func(tss []protoparser.TimeSerie) {
-				for _, e := range es {
-					e.insertMany(tss)
+				esLen := uint32(len(es))
+				start := fastrand.Uint32n(esLen)
+				for j := uint32(0); j < esLen; j++ {
+					i := (start + j) % esLen
+					es[i].insertMany(tss)
 				}
 			})
 			if err != nil {

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -1,0 +1,25 @@
+---
+build:
+  list: never
+  publishResources: false
+  render: never
+sitemap:
+  disable: true
+---
+
+The following `tip` changes can be tested by building vmestimator from the latest commits according to the following docs:
+
+* [How to build vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/#how-to-build-from-sources)
+
+Metrics of the latest version of vmestimator cluster are available for viewing at our
+[sandbox](https://play-grafana.victoriametrics.com/d/mkv22l4).
+
+## tip
+
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): randomize estimator iteration order to reduce lock contention. See [#15](https://github.com/VictoriaMetrics/vmestimator/pull/15).
+
+## [v0.1.6](https://github.com/VictoriaMetrics/vmestimator/releases/tag/v0.1.6)
+
+Released at 2026-07-07
+
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): initial release

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/VictoriaMetrics/vmestimator
 
-go 1.26.4
+go 1.26.5
 
 replace github.com/axiomhq/hyperloglog => github.com/makasim/hyperloglog v0.0.12-reuse-memory
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33
 	github.com/golang/snappy v1.0.0
+	github.com/valyala/fastrand v1.1.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -21,7 +22,6 @@ require (
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fastrand v1.1.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/valyala/gozstd v1.24.0 // indirect
 	github.com/valyala/histogram v1.2.0 // indirect


### PR DESCRIPTION
When multiple remote write requests arrive concurrently, each goroutine iterates the `es` slice in the same sequential order (0..N-1). This creates lock waves: all goroutines compete for the same estimator at the same time, then move to the next one in a lockstep.

Picking a random start index and iterating with wrap-around spreads concurrent goroutines across different estimators, reducing contention and improving throughput under parallel load.

Do the same in the bucket's insertMany while iterating over tss.

benchmark:
```
./bin/vmestimator -config=streams.yaml  -maxInsertRequestSize=500MiB -maxConcurrentInserts=100

avalanche --gauge-metric-count=2000 --series-count=1000 --metricname-length=20 --labelname-length=20 --series-interval=0 --remote-url=http://127.0.0.1:8490/api/v1/write --remote-write-interval=1s --remote-batch-size=30000 --remote-requests-count=-1
```

results:
```
$ go tool pprof -text -diff_base /tmp/mutex_main3.prof /tmp/mutex.prof
File: vmestimator
Type: delay
Time: 2026-07-07 23:34:08 EEST
Showing nodes accounting for -688.53ms, 60.24% of 1142.92ms total
Dropped 12 nodes (cum <= 5.71ms)
      flat  flat%   sum%        cum   cum%
 -688.53ms 60.24% 60.24%  -688.53ms 60.24%  sync.(*Mutex).Unlock
         0     0% 60.24%  -106.93ms  9.36%  github.com/VictoriaMetrics/VictoriaMetrics/lib/appmetrics.WritePrometheusMetrics
         0     0% 60.24%  -106.93ms  9.36%  github.com/VictoriaMetrics/VictoriaMetrics/lib/appmetrics.writePrometheusMetrics
         0     0% 60.24%  -688.53ms 60.24%  github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver.builtinRoutesHandler
         0     0% 60.24%  -688.53ms 60.24%  github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver.handlerWrapper
         0     0% 60.24%  -688.53ms 60.24%  github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver.serveWithListener.func2
         0     0% 60.24%  -688.53ms 60.24%  github.com/VictoriaMetrics/VictoriaMetrics/lib/httpserver.serveWithListener.func3
         0     0% 60.24%  -581.60ms 50.89%  github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/protoparserutil.ReadUncompressedData
         0     0% 60.24%  -581.59ms 50.89%  github.com/VictoriaMetrics/VictoriaMetrics/lib/protoparser/protoparserutil.readFull
         0     0% 60.24%  -106.93ms  9.36%  github.com/VictoriaMetrics/metrics.(*Set).WritePrometheus
         0     0% 60.24%  -106.93ms  9.36%  github.com/VictoriaMetrics/metrics.WritePrometheus
         0     0% 60.24%  -581.59ms 50.89%  github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser.(*writeRequestUnmarshaler).UnmarshalProtobuf
         0     0% 60.24%  -581.60ms 50.89%  github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser.Parse
         0     0% 60.24%  -581.59ms 50.89%  github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser.Parse.func1
         0     0% 60.24%  -581.59ms 50.89%  github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser.parseRequestBody
         0     0% 60.24%  -581.59ms 50.89%  github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser.parseRequestBody.func1
         0     0% 60.24%  -688.53ms 60.24%  github.com/klauspost/compress/gzhttp.NewWrapper.func1.1
         0     0% 60.24%  -581.59ms 50.89%  main.(*estimator).insertMany
         0     0% 60.24%  -106.93ms  9.36%  main.(*estimator).writeMetrics
         0     0% 60.24%  -581.59ms 50.89%  main.(*estimatorBucket).insert
         0     0% 60.24%  -106.93ms  9.36%  main.(*estimatorBucket).writeGroupMetrics
         0     0% 60.24%  -106.93ms  9.36%  main.main.func1
         0     0% 60.24%  -581.60ms 50.89%  main.main.func2
         0     0% 60.24%  -581.59ms 50.89%  main.main.func2.1
         0     0% 60.24%  -106.93ms  9.36%  main.writeCardinalityMetrics
         0     0% 60.24%  -688.53ms 60.24%  net/http.(*Server).Serve.gowrap3
         0     0% 60.24%  -688.53ms 60.24%  net/http.(*conn).serve
         0     0% 60.24%  -688.53ms 60.24%  net/http.HandlerFunc.ServeHTTP
         0     0% 60.24%  -688.53ms 60.24%  net/http.serverHandler.ServeHTTP
```

go test -run=none -count=10 ./app/vmestimator/ -bench=BenchmarkEstimator_InsertManyParallel -mutexprofile=rand_mutex.out
```
$ go tool pprof -text -diff_base mutex.out rand_mutex.out
File: vmestimator.test
Type: delay
Time: 2026-07-08 14:20:52 EEST
Showing nodes accounting for -14.25s, 14.05% of 101.43s total
Dropped 156 nodes (cum <= 0.51s)
      flat  flat%   sum%        cum   cum%
   -14.02s 13.82% 13.82%    -14.13s 13.93%  sync.(*Mutex).Unlock (partial-inline)
    -0.23s  0.23% 14.05%     -0.23s  0.23%  runtime.unlock (inline)
         0     0% 14.05%    -14.21s 14.01%  github.com/VictoriaMetrics/vmestimator/app/vmestimator.(*estimator).insertMany
         0     0% 14.05%    -14.22s 14.02%  github.com/VictoriaMetrics/vmestimator/app/vmestimator.(*estimatorBucket).insert
         0     0% 14.05%     -0.11s  0.11%  github.com/VictoriaMetrics/vmestimator/app/vmestimator.(*groupSize).allowInsertLocked
         0     0% 14.05%     -3.37s  3.32%  github.com/VictoriaMetrics/vmestimator/app/vmestimator.BenchmarkEstimator_InsertManyParallel.func1.1
         0     0% 14.05%     -3.74s  3.69%  github.com/VictoriaMetrics/vmestimator/app/vmestimator.BenchmarkEstimator_InsertManyParallel.func2.1
         0     0% 14.05%     -4.52s  4.46%  github.com/VictoriaMetrics/vmestimator/app/vmestimator.BenchmarkEstimator_InsertManyParallel.func3.1
         0     0% 14.05%     -2.59s  2.55%  github.com/VictoriaMetrics/vmestimator/app/vmestimator.BenchmarkEstimator_InsertManyParallel.func4.1
         0     0% 14.05%     -0.09s 0.087%  internal/sync.(*Mutex).Lock (inline)
         0     0% 14.05%     -0.11s  0.11%  internal/sync.(*Mutex).Unlock (inline)
         0     0% 14.05%     -0.09s 0.087%  internal/sync.(*Mutex).lockSlow
         0     0% 14.05%     -0.11s  0.11%  internal/sync.(*Mutex).unlockSlow
         0     0% 14.05%     -0.09s 0.087%  internal/sync.runtime_SemacquireMutex
         0     0% 14.05%     -0.11s  0.11%  internal/sync.runtime_Semrelease
         0     0% 14.05%     -0.09s 0.087%  runtime.semacquire1
         0     0% 14.05%     -0.11s  0.11%  runtime.semrelease1
         0     0% 14.05%     -0.09s 0.087%  sync.(*Mutex).Lock (inline)
         0     0% 14.05%    -14.22s 14.02%  testing.(*B).RunParallel.func1
```