### PR TITLE
app/vmestimator/protoparser: drop groupLabels filter, always expose all labels per time series

### DIFF
--- a/app/vmestimator/config.go
+++ b/app/vmestimator/config.go
@@ -45,18 +45,6 @@ func loadConfig(path string) ([]*estimator, error) {
 		if stream.HLLPrecision != 0 && (stream.HLLPrecision < 4 || stream.HLLPrecision > 18) {
 			return nil, fmt.Errorf("invalid precision %d: must be in range [4, 18]", stream.HLLPrecision)
 		}
-		if stream.Deeper != nil {
-			if len(stream.GroupBy) == 0 {
-				return nil, fmt.Errorf("stream with deeper requires non-empty group_by")
-			}
-			if len(stream.Deeper.GroupBy) == 0 {
-				return nil, fmt.Errorf("stream.deeper.group_by must not be empty")
-			}
-			if stream.Deeper.TopN <= 0 {
-				return nil, fmt.Errorf("stream.deeper.top_n must be positive; got %d", stream.Deeper.TopN)
-			}
-			sort.Strings(stream.Deeper.GroupBy)
-		}
 	}
 
 	es := make([]*estimator, 0, len(cfg.Streams))

--- a/app/vmestimator/config.go
+++ b/app/vmestimator/config.go
@@ -14,12 +14,6 @@ type Config struct {
 	Streams []EstimatorConfig `yaml:"streams"`
 }
 
-type DeeperConfig struct {
-	GroupBy    []string `yaml:"group_by"`
-	TopN       int      `yaml:"top_n"`
-	GroupLimit int      `yaml:"group_limit"`
-}
-
 type EstimatorConfig struct {
 	GroupBy      []string          `yaml:"group_by"`
 	GroupLimit   int               `yaml:"group_limit"`
@@ -28,7 +22,6 @@ type EstimatorConfig struct {
 	Buckets      int               `yaml:"buckets"`
 	HLLPrecision uint8             `yaml:"hll_precision"`
 	HLLSparse    *bool             `yaml:"hll_sparse"`
-	Deeper       *DeeperConfig     `yaml:"deeper"`
 }
 
 func loadConfig(path string) ([]*estimator, error) {

--- a/app/vmestimator/config.go
+++ b/app/vmestimator/config.go
@@ -14,6 +14,12 @@ type Config struct {
 	Streams []EstimatorConfig `yaml:"streams"`
 }
 
+type DeeperConfig struct {
+	GroupBy    []string `yaml:"group_by"`
+	TopN       int      `yaml:"top_n"`
+	GroupLimit int      `yaml:"group_limit"`
+}
+
 type EstimatorConfig struct {
 	GroupBy      []string          `yaml:"group_by"`
 	GroupLimit   int               `yaml:"group_limit"`
@@ -22,6 +28,7 @@ type EstimatorConfig struct {
 	Buckets      int               `yaml:"buckets"`
 	HLLPrecision uint8             `yaml:"hll_precision"`
 	HLLSparse    *bool             `yaml:"hll_sparse"`
+	Deeper       *DeeperConfig     `yaml:"deeper"`
 }
 
 func loadConfig(path string) ([]*estimator, error) {
@@ -44,6 +51,18 @@ func loadConfig(path string) ([]*estimator, error) {
 		sort.Strings(stream.GroupBy)
 		if stream.HLLPrecision != 0 && (stream.HLLPrecision < 4 || stream.HLLPrecision > 18) {
 			return nil, fmt.Errorf("invalid precision %d: must be in range [4, 18]", stream.HLLPrecision)
+		}
+		if stream.Deeper != nil {
+			if len(stream.GroupBy) == 0 {
+				return nil, fmt.Errorf("stream with deeper requires non-empty group_by")
+			}
+			if len(stream.Deeper.GroupBy) == 0 {
+				return nil, fmt.Errorf("stream.deeper.group_by must not be empty")
+			}
+			if stream.Deeper.TopN <= 0 {
+				return nil, fmt.Errorf("stream.deeper.top_n must be positive; got %d", stream.Deeper.TopN)
+			}
+			sort.Strings(stream.Deeper.GroupBy)
 		}
 	}
 

--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -196,7 +196,7 @@ func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 				groupValuesKey = append(groupValuesKey, ',')
 			}
 
-			for _, l := range ts.GroupLabels {
+			for _, l := range ts.Labels {
 				if l.Name == labelName {
 					hasNames = true
 

--- a/app/vmestimator/estimator_timing_test.go
+++ b/app/vmestimator/estimator_timing_test.go
@@ -160,7 +160,7 @@ func BenchmarkEstimator_InsertManyParallel(b *testing.B) {
 			var i uint64
 			for pb.Next() {
 				e.insertMany([]protoparser.TimeSerie{{
-					GroupLabels: []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%100)}},
+					Labels: []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%100)}},
 					Fingerprint: i,
 				}})
 				i++
@@ -184,7 +184,7 @@ func BenchmarkEstimator_InsertManyParallel(b *testing.B) {
 			var i uint64
 			for pb.Next() {
 				e.insertMany([]protoparser.TimeSerie{{
-					GroupLabels: []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%10_000)}},
+					Labels: []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%10_000)}},
 					Fingerprint: i,
 				}})
 				i++
@@ -208,7 +208,7 @@ func BenchmarkEstimator_InsertManyParallel(b *testing.B) {
 			var i uint64
 			for pb.Next() {
 				e.insertMany([]protoparser.TimeSerie{{
-					GroupLabels: []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%100_000)}},
+					Labels: []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%100_000)}},
 					Fingerprint: i,
 				}})
 				i++
@@ -270,7 +270,7 @@ func insertSeriesIntoEstimator(e *estimator, numSeries, groupsNum int) {
 		}
 		e.insertMany([]protoparser.TimeSerie{
 			{
-				GroupLabels: labels,
+				Labels: labels,
 				Fingerprint: hash([]byte(fmt.Sprintf("foobarbaz%d", i))),
 			},
 		})

--- a/app/vmestimator/estimator_timing_test.go
+++ b/app/vmestimator/estimator_timing_test.go
@@ -160,7 +160,7 @@ func BenchmarkEstimator_InsertManyParallel(b *testing.B) {
 			var i uint64
 			for pb.Next() {
 				e.insertMany([]protoparser.TimeSerie{{
-					Labels: []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%100)}},
+					Labels:      []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%100)}},
 					Fingerprint: i,
 				}})
 				i++
@@ -184,7 +184,7 @@ func BenchmarkEstimator_InsertManyParallel(b *testing.B) {
 			var i uint64
 			for pb.Next() {
 				e.insertMany([]protoparser.TimeSerie{{
-					Labels: []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%10_000)}},
+					Labels:      []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%10_000)}},
 					Fingerprint: i,
 				}})
 				i++
@@ -208,7 +208,7 @@ func BenchmarkEstimator_InsertManyParallel(b *testing.B) {
 			var i uint64
 			for pb.Next() {
 				e.insertMany([]protoparser.TimeSerie{{
-					Labels: []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%100_000)}},
+					Labels:      []protoparser.Label{{Name: "groupLabel", Value: fmt.Sprintf("%d", i%100_000)}},
 					Fingerprint: i,
 				}})
 				i++
@@ -270,7 +270,7 @@ func insertSeriesIntoEstimator(e *estimator, numSeries, groupsNum int) {
 		}
 		e.insertMany([]protoparser.TimeSerie{
 			{
-				Labels: labels,
+				Labels:      labels,
 				Fingerprint: hash([]byte(fmt.Sprintf("foobarbaz%d", i))),
 			},
 		})

--- a/app/vmestimator/etimator_test.go
+++ b/app/vmestimator/etimator_test.go
@@ -503,7 +503,7 @@ vmestimator_estimator_group_limit{interval="1h0m0s",group_by_keys="__group__",gr
 		return func(e *estimator) {
 			e.insertMany([]protoparser.TimeSerie{
 				{
-					Labels: []protoparser.Label{{Name: "foo", Value: fooVal}},
+					Labels:      []protoparser.Label{{Name: "foo", Value: fooVal}},
 					Fingerprint: hash([]byte("foo=" + fooVal + ",")),
 				},
 			})
@@ -539,7 +539,7 @@ vmestimator_estimator_group_limit{interval="1h0m0s",group_by_keys="__group__",gr
 func TestGroupEstimateGroupLimit(t *testing.T) {
 	makeTS := func(fooVal string) protoparser.TimeSerie {
 		return protoparser.TimeSerie{
-			Labels: []protoparser.Label{{Name: "foo", Value: fooVal}},
+			Labels:      []protoparser.Label{{Name: "foo", Value: fooVal}},
 			Fingerprint: hash([]byte("foo=" + fooVal + ",")),
 		}
 	}

--- a/app/vmestimator/etimator_test.go
+++ b/app/vmestimator/etimator_test.go
@@ -173,18 +173,18 @@ func TestGroupEstimate(t *testing.T) {
 				for barI := 0; barI < max(1, barCard); barI++ {
 					for bazI := 0; bazI < max(1, bazCard); bazI++ {
 						ts := protoparser.TimeSerie{}
-						ts.GroupLabels = append(ts.GroupLabels, protoparser.Label{Name: "__name__", Value: "the_metric_name"})
+						ts.Labels = append(ts.Labels, protoparser.Label{Name: "__name__", Value: "the_metric_name"})
 						if fooCard > 0 {
-							ts.GroupLabels = append(ts.GroupLabels, protoparser.Label{Name: "foo", Value: fmt.Sprintf("%s%d", seed, fooI)})
+							ts.Labels = append(ts.Labels, protoparser.Label{Name: "foo", Value: fmt.Sprintf("%s%d", seed, fooI)})
 						}
 						if barCard > 0 {
-							ts.GroupLabels = append(ts.GroupLabels, protoparser.Label{Name: "bar", Value: fmt.Sprintf("%s%d", seed, barI)})
+							ts.Labels = append(ts.Labels, protoparser.Label{Name: "bar", Value: fmt.Sprintf("%s%d", seed, barI)})
 						}
 						if bazCard > 0 {
-							ts.GroupLabels = append(ts.GroupLabels, protoparser.Label{Name: "baz", Value: fmt.Sprintf("%s%d", seed, bazI)})
+							ts.Labels = append(ts.Labels, protoparser.Label{Name: "baz", Value: fmt.Sprintf("%s%d", seed, bazI)})
 						}
 						var fpBuf []byte
-						for _, l := range ts.GroupLabels {
+						for _, l := range ts.Labels {
 							fpBuf = append(fpBuf, l.Name...)
 							fpBuf = append(fpBuf, '=')
 							fpBuf = append(fpBuf, l.Value...)
@@ -503,7 +503,7 @@ vmestimator_estimator_group_limit{interval="1h0m0s",group_by_keys="__group__",gr
 		return func(e *estimator) {
 			e.insertMany([]protoparser.TimeSerie{
 				{
-					GroupLabels: []protoparser.Label{{Name: "foo", Value: fooVal}},
+					Labels: []protoparser.Label{{Name: "foo", Value: fooVal}},
 					Fingerprint: hash([]byte("foo=" + fooVal + ",")),
 				},
 			})
@@ -539,7 +539,7 @@ vmestimator_estimator_group_limit{interval="1h0m0s",group_by_keys="__group__",gr
 func TestGroupEstimateGroupLimit(t *testing.T) {
 	makeTS := func(fooVal string) protoparser.TimeSerie {
 		return protoparser.TimeSerie{
-			GroupLabels: []protoparser.Label{{Name: "foo", Value: fooVal}},
+			Labels: []protoparser.Label{{Name: "foo", Value: fooVal}},
 			Fingerprint: hash([]byte("foo=" + fooVal + ",")),
 		}
 	}

--- a/app/vmestimator/main.go
+++ b/app/vmestimator/main.go
@@ -48,18 +48,6 @@ func main() {
 		})
 	}
 
-	groupLabelsMap := make(map[string]struct{})
-	for _, e := range es {
-		for _, l := range e.groupBy {
-			groupLabelsMap[l] = struct{}{}
-		}
-	}
-
-	groupLabels := make([]string, 0, len(groupLabelsMap))
-	for k := range groupLabelsMap {
-		groupLabels = append(groupLabels, k)
-	}
-
 	listenAddrs := *httpListenAddrs
 	if len(listenAddrs) == 0 {
 		listenAddrs = []string{":8490"}
@@ -80,7 +68,7 @@ func main() {
 		switch path {
 		case "/api/v1/write":
 			prometheusWriteRequests.Inc()
-			err := protoparser.Parse(r.Body, groupLabels, func(tss []protoparser.TimeSerie) {
+			err := protoparser.Parse(r.Body, func(tss []protoparser.TimeSerie) {
 				esLen := uint32(len(es))
 				start := fastrand.Uint32n(esLen)
 				for j := uint32(0); j < esLen; j++ {

--- a/app/vmestimator/protoparser/streamparser.go
+++ b/app/vmestimator/protoparser/streamparser.go
@@ -18,12 +18,12 @@ var maxInsertRequestSize = flagutil.NewBytes("maxInsertRequestSize", 32*1024*102
 // Parse parses Prometheus remote_write message from reader and calls callback for the parsed timeseries.
 //
 // callback shouldn't hold tss after returning.
-func Parse(r io.Reader, groupLabels []string, callback func(tss []TimeSerie)) error {
+func Parse(r io.Reader, callback func(tss []TimeSerie)) error {
 	startTime := fasttime.UnixTimestamp()
 
 	readCalls.Inc()
 	err := protoparserutil.ReadUncompressedData(r, "", maxInsertRequestSize, func(data []byte) error {
-		return parseRequestBody(data, groupLabels, callback)
+		return parseRequestBody(data, callback) //nolint:unparam
 	})
 	if err != nil {
 		readErrors.Inc()
@@ -32,7 +32,7 @@ func Parse(r io.Reader, groupLabels []string, callback func(tss []TimeSerie)) er
 	return nil
 }
 
-func parseRequestBody(data []byte, groupLabels []string, callback func(tss []TimeSerie)) error {
+func parseRequestBody(data []byte, callback func(tss []TimeSerie)) error {
 	// Synchronously process the request in order to properly return errors to Parse caller,
 	// so it could properly return HTTP 503 status code in response.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/896
@@ -57,7 +57,7 @@ func parseRequestBody(data []byte, groupLabels []string, callback func(tss []Tim
 	}
 	wru := getWriteRequestUnmarshaler()
 	defer putWriteRequestUnmarshaler(wru)
-	if err := wru.UnmarshalProtobuf(bb.B, groupLabels, func(tss []TimeSerie) {
+	if err := wru.UnmarshalProtobuf(bb.B, func(tss []TimeSerie) {
 		rowsRead.Add(len(tss))
 		callback(tss)
 	}); err != nil {

--- a/app/vmestimator/protoparser/streamparser_timing_test.go
+++ b/app/vmestimator/protoparser/streamparser_timing_test.go
@@ -12,14 +12,6 @@ import (
 
 func BenchmarkParse(b *testing.B) {
 	data := buildSnappyEncodedWriteRequest(5000, 20, 20, 3)
-	groupLabels := []string{
-		"foo",
-		"bar",
-		"baz",
-		"__name__",
-		"job",
-		"groupLabel",
-	}
 
 	var cnt int
 
@@ -27,7 +19,7 @@ func BenchmarkParse(b *testing.B) {
 	b.ReportAllocs()
 	b.SetBytes(int64(len(data)))
 	for b.Loop() {
-		err := Parse(bytes.NewReader(data), groupLabels, func(tss []TimeSerie) {
+		err := Parse(bytes.NewReader(data), func(tss []TimeSerie) {
 			cnt += len(tss)
 		})
 		if err != nil {

--- a/app/vmestimator/protoparser/write_request.go
+++ b/app/vmestimator/protoparser/write_request.go
@@ -2,7 +2,6 @@ package protoparser
 
 import (
 	"fmt"
-	"slices"
 	"sync"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
@@ -11,7 +10,7 @@ import (
 )
 
 type TimeSerie struct {
-	GroupLabels []Label
+	Labels      []Label
 	Fingerprint uint64
 }
 
@@ -56,7 +55,7 @@ func (wru *writeRequestUnmarshaler) Reset() {
 	wru.d.Reset()
 }
 
-func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, groupLabels []string, callback func(tss []TimeSerie)) error {
+func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, callback func(tss []TimeSerie)) error {
 	wru.Reset()
 
 	var err error
@@ -91,7 +90,7 @@ func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, groupLabels []
 			ts := &tss[len(tss)-1]
 			d := wru.d
 			d.Reset()
-			labelsPool, err = ts.unmarshalProtobuf(data, groupLabels, labelsPool, d)
+			labelsPool, err = ts.unmarshalProtobuf(data, labelsPool, d)
 			if err != nil {
 				return fmt.Errorf("cannot unmarshal timeseries: %w", err)
 			}
@@ -110,7 +109,7 @@ func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, groupLabels []
 	return nil
 }
 
-func (ts *TimeSerie) unmarshalProtobuf(src []byte, groupLabels []string, labelsPool []Label, d *xxhash.Digest) ([]Label, error) {
+func (ts *TimeSerie) unmarshalProtobuf(src []byte, labelsPool []Label, d *xxhash.Digest) ([]Label, error) {
 	// message TimeSeries {
 	//   repeated Label labels   = 1;
 	//   repeated Sample samples = 2;
@@ -155,16 +154,13 @@ func (ts *TimeSerie) unmarshalProtobuf(src []byte, groupLabels []string, labelsP
 
 			_, _ = d.Write(data)
 
-			name := bytesutil.ToUnsafeString(nameBytes)
-			if slices.Contains(groupLabels, name) {
-				labelsPool = append(labelsPool, Label{
-					Name:  name,
-					Value: bytesutil.ToUnsafeString(valueBytes),
-				})
-			}
+			labelsPool = append(labelsPool, Label{
+				Name:  bytesutil.ToUnsafeString(nameBytes),
+				Value: bytesutil.ToUnsafeString(valueBytes),
+			})
 		}
 	}
-	ts.GroupLabels = labelsPool[labelsPoolLen:]
+	ts.Labels = labelsPool[labelsPoolLen:]
 	ts.Fingerprint = d.Sum64()
 	return labelsPool, nil
 }

--- a/app/vmestimator/protoparser/write_request_timing_test.go
+++ b/app/vmestimator/protoparser/write_request_timing_test.go
@@ -15,15 +15,6 @@ func BenchmarkWriteRequest_UnmarshalProtobuf(b *testing.B) {
 		bName := fmt.Sprintf("Rows=%d/Labels=%d/LabelSize=%d/GroupBy=%d", rows, labels, labelSize, groupBy)
 		b.Run(bName, func(b *testing.B) {
 			data := buildEncodedWriteRequest(data, rows, labels, labelSize, groupBy)
-			groupLabels := []string{
-				"foo",
-				"bar",
-				"baz",
-				"__name__",
-				"job",
-				"groupLabel",
-			}
-
 			wru := getWriteRequestUnmarshaler()
 			cnt := 0
 
@@ -32,7 +23,7 @@ func BenchmarkWriteRequest_UnmarshalProtobuf(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for b.Loop() {
 				wru.Reset()
-				if err := wru.UnmarshalProtobuf(data, groupLabels, func(tss []TimeSerie) {
+				if err := wru.UnmarshalProtobuf(data, func(tss []TimeSerie) {
 					cnt += len(tss)
 				}); err != nil {
 					b.Fatalf("unexpected error: %s", err)

--- a/app/vmestimator/snapshot_test.go
+++ b/app/vmestimator/snapshot_test.go
@@ -156,18 +156,18 @@ func TestGroupSnapshot(t *testing.T) {
 				for barI := 0; barI < max(1, barCard); barI++ {
 					for bazI := 0; bazI < max(1, bazCard); bazI++ {
 						ts := protoparser.TimeSerie{}
-						ts.GroupLabels = append(ts.GroupLabels, protoparser.Label{Name: "__name__", Value: "the_metric_name"})
+						ts.Labels = append(ts.Labels, protoparser.Label{Name: "__name__", Value: "the_metric_name"})
 						if fooCard > 0 {
-							ts.GroupLabels = append(ts.GroupLabels, protoparser.Label{Name: "foo", Value: fmt.Sprintf("%s%d", seed, fooI)})
+							ts.Labels = append(ts.Labels, protoparser.Label{Name: "foo", Value: fmt.Sprintf("%s%d", seed, fooI)})
 						}
 						if barCard > 0 {
-							ts.GroupLabels = append(ts.GroupLabels, protoparser.Label{Name: "bar", Value: fmt.Sprintf("%s%d", seed, barI)})
+							ts.Labels = append(ts.Labels, protoparser.Label{Name: "bar", Value: fmt.Sprintf("%s%d", seed, barI)})
 						}
 						if bazCard > 0 {
-							ts.GroupLabels = append(ts.GroupLabels, protoparser.Label{Name: "baz", Value: fmt.Sprintf("%s%d", seed, bazI)})
+							ts.Labels = append(ts.Labels, protoparser.Label{Name: "baz", Value: fmt.Sprintf("%s%d", seed, bazI)})
 						}
 						var fpBuf []byte
-						for _, l := range ts.GroupLabels {
+						for _, l := range ts.Labels {
 							fpBuf = append(fpBuf, l.Name...)
 							fpBuf = append(fpBuf, '=')
 							fpBuf = append(fpBuf, l.Value...)
@@ -365,7 +365,7 @@ func TestGroupSnapshot(t *testing.T) {
 		return func(e *estimator) {
 			e.insertMany([]protoparser.TimeSerie{
 				{
-					GroupLabels: []protoparser.Label{{Name: "foo", Value: fooVal}},
+					Labels: []protoparser.Label{{Name: "foo", Value: fooVal}},
 					Fingerprint: hash([]byte("foo=" + fooVal + ",")),
 				},
 			})
@@ -382,7 +382,7 @@ func TestGroupSnapshot(t *testing.T) {
 func TestGroupSnapshotGroupLimit(t *testing.T) {
 	makeTS := func(fooVal string) protoparser.TimeSerie {
 		return protoparser.TimeSerie{
-			GroupLabels: []protoparser.Label{{Name: "foo", Value: fooVal}},
+			Labels: []protoparser.Label{{Name: "foo", Value: fooVal}},
 			Fingerprint: hash([]byte("foo=" + fooVal + ",")),
 		}
 	}

--- a/app/vmestimator/snapshot_test.go
+++ b/app/vmestimator/snapshot_test.go
@@ -365,7 +365,7 @@ func TestGroupSnapshot(t *testing.T) {
 		return func(e *estimator) {
 			e.insertMany([]protoparser.TimeSerie{
 				{
-					Labels: []protoparser.Label{{Name: "foo", Value: fooVal}},
+					Labels:      []protoparser.Label{{Name: "foo", Value: fooVal}},
 					Fingerprint: hash([]byte("foo=" + fooVal + ",")),
 				},
 			})
@@ -382,7 +382,7 @@ func TestGroupSnapshot(t *testing.T) {
 func TestGroupSnapshotGroupLimit(t *testing.T) {
 	makeTS := func(fooVal string) protoparser.TimeSerie {
 		return protoparser.TimeSerie{
-			Labels: []protoparser.Label{{Name: "foo", Value: fooVal}},
+			Labels:      []protoparser.Label{{Name: "foo", Value: fooVal}},
 			Fingerprint: hash([]byte("foo=" + fooVal + ",")),
 		}
 	}


### PR DESCRIPTION
The upcoming `__label__` group_by keyword (see https://github.com/VictoriaMetrics/vmestimator/issues/26) needs access to every label on each time series to expand it into per-label-name sketches. One way to solve it is to introduce a separate allLabels pool alongside the filtered one. It would complicate the parser unnecessarily and tie parser to estimator logic even more.

Dropping the filter simplifies the API to a single Labels field and removes the groupLabels parameter. Benchmarks show 5–11% parser throughput gain with negligible impact on estimator insert performance.

```
$ benchstat baseline.bench refactor.bench
goos: darwin
goarch: arm64
pkg: github.com/VictoriaMetrics/vmestimator/app/vmestimator
cpu: Apple M1 Pro
                                            │ baseline.bench │
refactor.bench           │
                                            │     sec/op     │   sec/op
vs base               │
Estimator_WriteMetrics/NoGroup/NoPrev-10        752.9µ ±  2%   763.8µ ±
3%       ~ (p=0.796 n=10)
Estimator_WriteMetrics/NoGroup/WithPrev-10      1.462m ±  2%   1.468m ±
1%       ~ (p=0.631 n=10)
Estimator_WriteMetrics/Group100/NoPrev-10       239.0µ ±  3%   237.0µ ±
2%       ~ (p=0.481 n=10)
Estimator_WriteMetrics/Group100/WithPrev-10     303.6µ ±  2%   303.5µ ±
2%       ~ (p=1.000 n=10)
Estimator_WriteMetrics/Group10k/NoPrev-10       2.751m ±  4%   2.700m ±
4%  -1.88% (p=0.043 n=10)
Estimator_WriteMetrics/Group10k/WithPrev-10     4.566m ± 14%   4.245m ±
8%  -7.03% (p=0.011 n=10)
Estimator_InsertManyParallel/NoGroup-10         75.86n ±  3%   76.51n ±
4%       ~ (p=0.684 n=10)
Estimator_InsertManyParallel/Group100-10        80.31n ±  4%   79.03n ±
2%       ~ (p=0.052 n=10)
Estimator_InsertManyParallel/Group10k-10        82.55n ±  5%   81.73n ±
1%       ~ (p=0.075 n=10)
Estimator_InsertManyParallel/Group100k-10       205.6n ± 22%   203.5n ±
5%       ~ (p=0.305 n=10)
Estimator_InsertRotateCycle/SparseHLL-10        121.9µ ±  2%   118.3µ ±
0%  -2.92% (p=0.001 n=10)
Estimator_InsertRotateCycle/NormalHLL-10        5.703m ±  1%   5.482m ±
0%  -3.88% (p=0.000 n=10)
geomean                                         45.17µ         44.50µ
-1.48%

                                            │ baseline.bench  │
refactor.bench             │
                                            │      B/op       │     B/op
vs base                 │
Estimator_WriteMetrics/NoGroup/NoPrev-10       42.36Ki ± 0%      42.34Ki
± 0%       ~ (p=0.796 n=10)
Estimator_WriteMetrics/NoGroup/WithPrev-10     63.32Ki ± 0%      63.27Ki
± 0%       ~ (p=1.000 n=10)
Estimator_WriteMetrics/Group100/NoPrev-10      37.70Ki ± 0%      37.70Ki
± 0%       ~ (p=0.739 n=10)
Estimator_WriteMetrics/Group100/WithPrev-10    37.70Ki ± 0%      37.70Ki
± 0%       ~ (p=0.853 n=10)
Estimator_WriteMetrics/Group10k/NoPrev-10      16.51Ki ± 0%      16.51Ki
± 0%       ~ (p=0.128 n=10)
Estimator_WriteMetrics/Group10k/WithPrev-10    16.51Ki ± 0%      16.51Ki
± 0%       ~ (p=0.053 n=10)
Estimator_InsertManyParallel/NoGroup-10          0.000 ± 0%        0.000
± 0%       ~ (p=1.000 n=10) ¹
Estimator_InsertManyParallel/Group100-10         1.000 ± 0%        1.000
± 0%       ~ (p=1.000 n=10) ¹
Estimator_InsertManyParallel/Group10k-10         16.00 ± 6%        16.00
± 0%       ~ (p=0.582 n=10)
Estimator_InsertManyParallel/Group100k-10        19.00 ± 5%        19.00
± 5%       ~ (p=1.000 n=10)
Estimator_InsertRotateCycle/SparseHLL-10       47.59Ki ± 0%      47.59Ki
± 0%       ~ (p=1.000 n=10) ¹
Estimator_InsertRotateCycle/NormalHLL-10      1008.9Ki ± 0%     1008.9Ki
± 0%  -0.01% (p=0.002 n=10)
geomean                                                     ²
-0.01%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                            │ baseline.bench │
refactor.bench            │
                                            │   allocs/op    │
allocs/op   vs base                 │
Estimator_WriteMetrics/NoGroup/NoPrev-10        34.00 ± 0%      34.00 ±
0%       ~ (p=1.000 n=10) ¹
Estimator_WriteMetrics/NoGroup/WithPrev-10      54.00 ± 0%      54.00 ±
0%       ~ (p=1.000 n=10) ¹
Estimator_WriteMetrics/Group100/NoPrev-10       112.0 ± 0%      112.0 ±
0%       ~ (p=1.000 n=10) ¹
Estimator_WriteMetrics/Group100/WithPrev-10     112.0 ± 0%      112.0 ±
0%       ~ (p=1.000 n=10) ¹
Estimator_WriteMetrics/Group10k/NoPrev-10       9.000 ± 0%      9.000 ±
0%       ~ (p=1.000 n=10) ¹
Estimator_WriteMetrics/Group10k/WithPrev-10     9.000 ± 0%      9.000 ±
0%       ~ (p=1.000 n=10) ¹
Estimator_InsertManyParallel/NoGroup-10         0.000 ± 0%      0.000 ±
0%       ~ (p=1.000 n=10) ¹
Estimator_InsertManyParallel/Group100-10        0.000 ± 0%      0.000 ±
0%       ~ (p=1.000 n=10) ¹
Estimator_InsertManyParallel/Group10k-10        1.000 ± 0%      1.000 ±
0%       ~ (p=1.000 n=10) ¹
Estimator_InsertManyParallel/Group100k-10       2.000 ± 0%      2.000 ±
0%       ~ (p=1.000 n=10) ¹
Estimator_InsertRotateCycle/SparseHLL-10       1.961k ± 0%     1.961k ±
0%       ~ (p=1.000 n=10) ¹
Estimator_InsertRotateCycle/NormalHLL-10       60.16k ± 0%     60.16k ±
0%       ~ (p=1.000 n=10) ¹
geomean                                                    ²
+0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

pkg: github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser

│ baseline.bench │           refactor.bench            │

│     sec/op     │   sec/op     vs base                │
Parse-10
3.003m ± 3%   2.838m ± 3%   -5.48% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=0/LabelSize=0/GroupBy=3-10
172.5µ ± 3%   155.2µ ± 2%  -10.02% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=1/LabelSize=20/GroupBy=3-10
294.5µ ± 1%   277.0µ ± 2%   -5.93% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=20/GroupBy=3-10
445.9µ ± 2%   416.6µ ± 0%   -6.57% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=20/LabelSize=20/GroupBy=3-10
2.232m ± 1%   2.090m ± 1%   -6.37% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=10000/Labels=20/LabelSize=20/GroupBy=3-10
4.453m ± 0%   4.178m ± 0%   -6.18% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=20000/Labels=20/LabelSize=20/GroupBy=3-10
8.893m ± 1%   8.386m ± 1%   -5.71% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=2000/GroupBy=3-10
3.269m ± 2%   3.282m ± 3%        ~ (p=0.579 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=2000/LabelSize=100/GroupBy=3-10
51.50m ± 1%   50.25m ± 5%        ~ (p=0.089 n=10)
geomean
2.157m        2.041m        -5.41%

│ baseline.bench │             refactor.bench              │

│      B/op      │     B/op       vs base                  │
Parse-10
13.87Ki ± 2%     19.63Ki ±  1%  +41.49% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=0/LabelSize=0/GroupBy=3-10
0.000 ± 0%       0.000 ±  0%        ~ (p=1.000 n=10) ¹
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=1/LabelSize=20/GroupBy=3-10
0.000 ± 0%       0.000 ±  0%        ~ (p=1.000 n=10) ¹
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=20/GroupBy=3-10
0.0 ± 0%       991.0 ±  2%        ? (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=20/LabelSize=20/GroupBy=3-10
0.000Ki ± 0%     4.866Ki ±  5%        ? (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=10000/Labels=20/LabelSize=20/GroupBy=3-10
0.000Ki ± 0%     9.733Ki ±  0%        ? (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=20000/Labels=20/LabelSize=20/GroupBy=3-10
0.00Ki ± 0%     19.67Ki ±  1%        ? (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=2000/GroupBy=3-10
0.000Ki ± 0%     7.669Ki ±  2%        ? (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=2000/LabelSize=100/GroupBy=3-10
0.00Mi ± 0%     14.63Mi ± 10%        ? (p=0.000 n=10)
geomean
²                  ?                      ²
¹ all samples are equal
² summaries must be >0 to compute geomean

│ baseline.bench │         refactor.bench         │

│   allocs/op    │ allocs/op   vs base            │
Parse-10
1.000 ± 0%     1.000 ± 0%  ~ (p=1.000 n=10) ¹
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=0/LabelSize=0/GroupBy=3-10
0.000 ± 0%     0.000 ± 0%  ~ (p=1.000 n=10) ¹
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=1/LabelSize=20/GroupBy=3-10
0.000 ± 0%     0.000 ± 0%  ~ (p=1.000 n=10) ¹
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=20/GroupBy=3-10
0.000 ± 0%     0.000 ± 0%  ~ (p=1.000 n=10) ¹
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=20/LabelSize=20/GroupBy=3-10
0.000 ± 0%     0.000 ± 0%  ~ (p=1.000 n=10) ¹
WriteRequest_UnmarshalProtobuf/Rows=10000/Labels=20/LabelSize=20/GroupBy=3-10
0.000 ± 0%     0.000 ± 0%  ~ (p=1.000 n=10) ¹
WriteRequest_UnmarshalProtobuf/Rows=20000/Labels=20/LabelSize=20/GroupBy=3-10
0.000 ± 0%     0.000 ± 0%  ~ (p=1.000 n=10) ¹
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=2000/GroupBy=3-10
0.000 ± 0%     0.000 ± 0%  ~ (p=1.000 n=10) ¹
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=2000/LabelSize=100/GroupBy=3-10
0.000 ± 0%     1.000 ± 0%  ? (p=0.000 n=10)
geomean
²               ?                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

│ baseline.bench │            refactor.bench             │

│      B/s       │      B/s       vs base                │
Parse-10
155.9Mi ± 3%    164.9Mi ± 3%   +5.80% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=0/LabelSize=0/GroupBy=3-10
912.1Mi ± 3%   1013.6Mi ± 2%  +11.13% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=1/LabelSize=20/GroupBy=3-10
1.186Gi ± 1%    1.261Gi ± 2%   +6.31% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=20/GroupBy=3-10
1.825Gi ± 2%    1.954Gi ± 0%   +7.03% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=5000/Labels=20/LabelSize=20/GroupBy=3-10
1.823Gi ± 1%    1.947Gi ± 1%   +6.80% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=10000/Labels=20/LabelSize=20/GroupBy=3-10
1.828Gi ± 0%    1.948Gi ± 0%   +6.59% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=20000/Labels=20/LabelSize=20/GroupBy=3-10
1.831Gi ± 1%    1.941Gi ± 1%   +6.05% (p=0.000 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=20/LabelSize=2000/GroupBy=3-10
11.54Gi ± 2%    11.50Gi ± 3%        ~ (p=0.579 n=10)
WriteRequest_UnmarshalProtobuf/Rows=1000/Labels=2000/LabelSize=100/GroupBy=3-10
4.466Gi ± 1%    4.577Gi ± 5%        ~ (p=0.089 n=10)
geomean
1.653Gi         1.748Gi        +5.72%
```


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/VictoriaMetrics/vmestimator/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

