### PR TITLE
app/vmestimator: add __label__ pseudo-label to group_by

### DIFF
--- a/app/vmestimator/config.go
+++ b/app/vmestimator/config.go
@@ -45,6 +45,22 @@ func loadConfig(path string) ([]*estimator, error) {
 		if stream.HLLPrecision != 0 && (stream.HLLPrecision < 4 || stream.HLLPrecision > 18) {
 			return nil, fmt.Errorf("invalid precision %d: must be in range [4, 18]", stream.HLLPrecision)
 		}
+		count := 0
+		newGroupBy := make([]string, 0, len(stream.GroupBy))
+		for _, g := range stream.GroupBy {
+			if g == labelKeyword {
+				count++
+				continue
+			}
+			newGroupBy = append(newGroupBy, g)
+		}
+		if count > 1 {
+			return nil, fmt.Errorf("__label__ may appear at most once in group_by")
+		}
+		if count == 1 {
+			newGroupBy = append(newGroupBy, labelKeyword)
+		}
+		stream.GroupBy = newGroupBy
 	}
 
 	es := make([]*estimator, 0, len(cfg.Streams))

--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -22,10 +22,14 @@ import (
 	"github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser"
 )
 
+const labelKeyword = "__label__"
+
 type estimator struct {
 	groupBy          []string
 	groupByKeysLabel string
 	groupSize        *groupSize
+
+	hasLabelKeyword bool
 
 	buckets []*estimatorBucket
 
@@ -70,9 +74,18 @@ func newEstimator(cfg EstimatorConfig) (*estimator, error) {
 		groupByKeysLabel = strings.Join(cfg.GroupBy, `,`)
 	}
 
+	if len(cfg.GroupBy) > 0 {
+		for i, k := range cfg.GroupBy[:len(cfg.GroupBy)-1] {
+			if k == labelKeyword {
+				panic(fmt.Sprintf("BUG: %s must be the last element of groupBy, got index %d in %v", labelKeyword, i, cfg.GroupBy))
+			}
+		}
+	}
+
 	e := &estimator{
 		groupBy:          cfg.GroupBy,
 		groupByKeysLabel: groupByKeysLabel,
+		hasLabelKeyword:  len(cfg.GroupBy) > 0 && cfg.GroupBy[len(cfg.GroupBy)-1] == labelKeyword,
 		groupSize: &groupSize{
 			limit:          int64(cfg.GroupLimit),
 			bucketSizes:    make([]int64, cfg.Buckets),
@@ -100,8 +113,9 @@ func newEstimator(cfg EstimatorConfig) (*estimator, error) {
 			metricPrefix:     metricPrefix,
 			groupByKeysLabel: groupByKeysLabel,
 
-			precision: cfg.HLLPrecision,
-			sparse:    *cfg.HLLSparse,
+			precision:       cfg.HLLPrecision,
+			sparse:          *cfg.HLLSparse,
+			hasLabelKeyword: e.hasLabelKeyword,
 		}
 
 		if len(cfg.GroupBy) == 0 {
@@ -165,7 +179,7 @@ func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 
 			ts := tss[i]
 			bi := int(ts.Fingerprint % bucketsNum)
-			e.buckets[bi].insert(ts, "", nil)
+			e.buckets[bi].insert(ts.Fingerprint, "", nil)
 		}
 		e.insertTotal.Add(len(tss))
 		return
@@ -181,6 +195,12 @@ func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 
 	groupValues := make([]string, len(e.groupBy))
 
+	// When __label__ is present it is always the last element; iterate only the explicit keys.
+	groupByKeys := e.groupBy
+	if e.hasLabelKeyword {
+		groupByKeys = e.groupBy[:len(e.groupBy)-1]
+	}
+
 	tssLen := uint32(len(tss))
 	start := fastrand.Uint32n(tssLen)
 	for j := uint32(0); j < tssLen; j++ {
@@ -190,8 +210,9 @@ func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 
 		groupValuesKey = groupValuesKey[:0]
 		clear(groupValues)
-		var hasNames bool
-		for i, labelName := range e.groupBy {
+		// hasNames starts true when there are no explicit keys (pure __label__ mode).
+		hasNames := len(groupByKeys) == 0
+		for i, labelName := range groupByKeys {
 			if i > 0 {
 				groupValuesKey = append(groupValuesKey, ',')
 			}
@@ -212,9 +233,30 @@ func (e *estimator) insertMany(tss []protoparser.TimeSerie) {
 			continue
 		}
 
-		bi := int(hash(groupValuesKey) % bucketsNum)
-		e.buckets[bi].insert(ts, bytesutil.ToUnsafeString(groupValuesKey), groupValues)
-		cnt++
+		if !e.hasLabelKeyword {
+			bi := int(hash(groupValuesKey) % bucketsNum)
+			e.buckets[bi].insert(ts.Fingerprint, bytesutil.ToUnsafeString(groupValuesKey), groupValues)
+			cnt++
+			continue
+		}
+
+		// __label__ expansion: one insert per label in the series.
+		explicitKeyLen := len(groupValuesKey)
+		lastIdx := len(e.groupBy) - 1
+		for _, label := range ts.Labels {
+			if label.Fingerprint == 0 {
+				panic(fmt.Sprintf("BUG: label %q has zero Fingerprint; group_by contains %s", label.Name, labelKeyword))
+			}
+			groupValuesKey = groupValuesKey[:explicitKeyLen]
+			if explicitKeyLen > 0 {
+				groupValuesKey = append(groupValuesKey, ',')
+			}
+			groupValuesKey = append(groupValuesKey, label.Name...)
+			groupValues[lastIdx] = label.Name
+			bi := int(hash(groupValuesKey) % bucketsNum)
+			e.buckets[bi].insert(label.Fingerprint, bytesutil.ToUnsafeString(groupValuesKey), groupValues)
+			cnt++
+		}
 	}
 
 	e.insertTotal.Add(cnt)
@@ -334,6 +376,7 @@ type estimatorBucket struct {
 	groupByKeysLabel string
 	precision        uint8
 	sparse           bool
+	hasLabelKeyword  bool
 
 	sketch     *hyperloglog.Sketch
 	prevSketch *hyperloglog.Sketch
@@ -380,12 +423,12 @@ func (eb *estimatorBucket) rotate() {
 	eb.mu.Unlock()
 }
 
-func (eb *estimatorBucket) insert(ts protoparser.TimeSerie, groupValuesKey string, groupValues []string) {
+func (eb *estimatorBucket) insert(fp uint64, groupValuesKey string, groupValues []string) {
 	eb.mu.Lock()
 	defer eb.mu.Unlock()
 
 	if len(eb.groupBy) == 0 {
-		eb.sketch.InsertHash(ts.Fingerprint)
+		eb.sketch.InsertHash(fp)
 		return
 	}
 
@@ -404,9 +447,12 @@ func (eb *estimatorBucket) insert(ts protoparser.TimeSerie, groupValuesKey strin
 			formatBuf = strconv.AppendQuote(formatBuf, groupValuesKey)
 			for i := range groupValues {
 				formatBuf = append(formatBuf, ',')
-				if eb.groupBy[i] == `__name__` {
+				switch eb.groupBy[i] {
+				case `__name__`:
 					formatBuf = append(formatBuf, `by__name__`...)
-				} else {
+				case labelKeyword:
+					formatBuf = append(formatBuf, `by__label__`...)
+				default:
 					formatBuf = append(formatBuf, `by_`...)
 					formatBuf = append(formatBuf, eb.groupBy[i]...)
 				}
@@ -426,7 +472,7 @@ func (eb *estimatorBucket) insert(ts protoparser.TimeSerie, groupValuesKey strin
 
 		eb.groups[strings.Clone(groupValuesKey)] = gsk
 	}
-	gsk.InsertHash(ts.Fingerprint)
+	gsk.InsertHash(fp)
 }
 
 func (eb *estimatorBucket) writeNoGroupMetric(res *hyperloglog.Sketch) {

--- a/app/vmestimator/etimator_test.go
+++ b/app/vmestimator/etimator_test.go
@@ -628,6 +628,118 @@ func TestGroupEstimateGroupLimit(t *testing.T) {
 	)
 }
 
+func TestLabelKeywordEstimate(t *testing.T) {
+	makeLabel := func(name, value string) protoparser.Label {
+		return protoparser.Label{
+			Name:        name,
+			Value:       value,
+			Fingerprint: hash([]byte(value)),
+		}
+	}
+
+	f := func(groupBy []string, gen func(e *estimator), expMetrics string) {
+		t.Helper()
+
+		cfg := EstimatorConfig{
+			Interval:   time.Hour,
+			GroupBy:    groupBy,
+			GroupLimit: 12345,
+			Buckets:    5,
+		}
+
+		e, err := newEstimator(cfg)
+		if err != nil {
+			t.Fatalf("failed to create new estimator: %v", err)
+		}
+		defer e.stop()
+
+		gen(e)
+
+		buf := bytes.NewBuffer(nil)
+		e.writeMetrics(buf)
+		assertMetricsSame(t, "", expMetrics, buf.String())
+	}
+
+	// pure __label__: counts unique values per label name across all series
+	f([]string{"__label__"}, func(e *estimator) {
+		e.insertMany([]protoparser.TimeSerie{
+			{Labels: []protoparser.Label{
+				makeLabel("__name__", "m1"),
+				makeLabel("foo", "f1"),
+				makeLabel("bar", "b1"),
+			}},
+			{Labels: []protoparser.Label{
+				makeLabel("__name__", "m2"),
+				makeLabel("foo", "f1"),
+				makeLabel("bar", "b1"),
+			}},
+			{Labels: []protoparser.Label{
+				makeLabel("__name__", "m3"),
+				makeLabel("foo", "f2"),
+				makeLabel("bar", "b1"),
+			}},
+		})
+	}, `
+cardinality_estimate{interval="1h0m0s",group_by_keys="__group__",group_by_values="__label__"} 3
+cardinality_estimate{interval="1h0m0s",group_by_keys="__label__",group_by_values="__name__",by__label__="__name__"} 3
+cardinality_estimate{interval="1h0m0s",group_by_keys="__label__",group_by_values="foo",by__label__="foo"} 2
+cardinality_estimate{interval="1h0m0s",group_by_keys="__label__",group_by_values="bar",by__label__="bar"} 1
+vmestimator_estimator_group_limit{interval="1h0m0s",group_by_keys="__group__",group_by_values="__label__"} 12345`,
+	)
+
+	// __name__ + __label__: one sketch per (metric_name, label_name) pair
+	// GroupBy passed already sorted with __label__ last (as loadConfig would produce)
+	f([]string{"__name__", "__label__"}, func(e *estimator) {
+		e.insertMany([]protoparser.TimeSerie{
+			{Labels: []protoparser.Label{
+				makeLabel("__name__", "metric_a"),
+				makeLabel("foo", "f1"),
+				makeLabel("bar", "b1"),
+			}},
+			{Labels: []protoparser.Label{
+				makeLabel("__name__", "metric_a"),
+				makeLabel("foo", "f2"),
+				makeLabel("bar", "b1"),
+			}},
+			{Labels: []protoparser.Label{
+				makeLabel("__name__", "metric_b"),
+				makeLabel("foo", "f1"),
+			}},
+		})
+	}, `
+cardinality_estimate{interval="1h0m0s",group_by_keys="__group__",group_by_values="__name__,__label__"} 5
+cardinality_estimate{interval="1h0m0s",group_by_keys="__name__,__label__",group_by_values="metric_a,__name__",by__name__="metric_a",by__label__="__name__"} 1
+cardinality_estimate{interval="1h0m0s",group_by_keys="__name__,__label__",group_by_values="metric_a,foo",by__name__="metric_a",by__label__="foo"} 2
+cardinality_estimate{interval="1h0m0s",group_by_keys="__name__,__label__",group_by_values="metric_a,bar",by__name__="metric_a",by__label__="bar"} 1
+cardinality_estimate{interval="1h0m0s",group_by_keys="__name__,__label__",group_by_values="metric_b,__name__",by__name__="metric_b",by__label__="__name__"} 1
+cardinality_estimate{interval="1h0m0s",group_by_keys="__name__,__label__",group_by_values="metric_b,foo",by__name__="metric_b",by__label__="foo"} 1
+vmestimator_estimator_group_limit{interval="1h0m0s",group_by_keys="__group__",group_by_values="__name__,__label__"} 12345`,
+	)
+
+	// series missing an explicit group-by label are skipped entirely
+	f([]string{"foo", "__label__"}, func(e *estimator) {
+		e.insertMany([]protoparser.TimeSerie{
+			// has foo — contributes
+			{Labels: []protoparser.Label{
+				makeLabel("__name__", "m1"),
+				makeLabel("foo", "f1"),
+				makeLabel("bar", "b1"),
+			}},
+			// no foo — skipped
+			{Labels: []protoparser.Label{
+				makeLabel("__name__", "m2"),
+				makeLabel("bar", "b2"),
+			}},
+		})
+	}, `
+cardinality_estimate{interval="1h0m0s",group_by_keys="__group__",group_by_values="foo,__label__"} 3
+cardinality_estimate{interval="1h0m0s",group_by_keys="foo,__label__",group_by_values="f1,__name__",by_foo="f1",by__label__="__name__"} 1
+cardinality_estimate{interval="1h0m0s",group_by_keys="foo,__label__",group_by_values="f1,foo",by_foo="f1",by__label__="foo"} 1
+cardinality_estimate{interval="1h0m0s",group_by_keys="foo,__label__",group_by_values="f1,bar",by_foo="f1",by__label__="bar"} 1
+vmestimator_estimator_group_limit{interval="1h0m0s",group_by_keys="__group__",group_by_values="foo,__label__"} 12345`,
+	)
+}
+
 func assertMetricsSame(t *testing.T, msg, exp, act string) {
 	t.Helper()
 

--- a/app/vmestimator/main.go
+++ b/app/vmestimator/main.go
@@ -42,6 +42,15 @@ func main() {
 		logger.Fatalf("cannot load config: %v", err)
 	}
 
+	var labelFP bool
+	for _, e := range es {
+		for _, l := range e.groupBy {
+			if l == labelKeyword {
+				labelFP = true
+			}
+		}
+	}
+
 	if *cardinalityMetricsExposeAt == `/metrics` {
 		metrics.RegisterMetricsWriter(func(w io.Writer) {
 			writeCardinalityMetrics(w, es, *storageNodes)
@@ -68,7 +77,7 @@ func main() {
 		switch path {
 		case "/api/v1/write":
 			prometheusWriteRequests.Inc()
-			err := protoparser.Parse(r.Body, func(tss []protoparser.TimeSerie) {
+			err := protoparser.Parse(r.Body, labelFP, func(tss []protoparser.TimeSerie) {
 				esLen := uint32(len(es))
 				start := fastrand.Uint32n(esLen)
 				for j := uint32(0); j < esLen; j++ {

--- a/app/vmestimator/protoparser/streamparser.go
+++ b/app/vmestimator/protoparser/streamparser.go
@@ -18,12 +18,12 @@ var maxInsertRequestSize = flagutil.NewBytes("maxInsertRequestSize", 32*1024*102
 // Parse parses Prometheus remote_write message from reader and calls callback for the parsed timeseries.
 //
 // callback shouldn't hold tss after returning.
-func Parse(r io.Reader, callback func(tss []TimeSerie)) error {
+func Parse(r io.Reader, labelFP bool, callback func(tss []TimeSerie)) error {
 	startTime := fasttime.UnixTimestamp()
 
 	readCalls.Inc()
 	err := protoparserutil.ReadUncompressedData(r, "", maxInsertRequestSize, func(data []byte) error {
-		return parseRequestBody(data, callback) //nolint:unparam
+		return parseRequestBody(data, labelFP, callback) //nolint:unparam
 	})
 	if err != nil {
 		readErrors.Inc()
@@ -32,7 +32,7 @@ func Parse(r io.Reader, callback func(tss []TimeSerie)) error {
 	return nil
 }
 
-func parseRequestBody(data []byte, callback func(tss []TimeSerie)) error {
+func parseRequestBody(data []byte, labelFP bool, callback func(tss []TimeSerie)) error {
 	// Synchronously process the request in order to properly return errors to Parse caller,
 	// so it could properly return HTTP 503 status code in response.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/896
@@ -57,7 +57,7 @@ func parseRequestBody(data []byte, callback func(tss []TimeSerie)) error {
 	}
 	wru := getWriteRequestUnmarshaler()
 	defer putWriteRequestUnmarshaler(wru)
-	if err := wru.UnmarshalProtobuf(bb.B, func(tss []TimeSerie) {
+	if err := wru.UnmarshalProtobuf(bb.B, labelFP, func(tss []TimeSerie) {
 		rowsRead.Add(len(tss))
 		callback(tss)
 	}); err != nil {

--- a/app/vmestimator/protoparser/streamparser_timing_test.go
+++ b/app/vmestimator/protoparser/streamparser_timing_test.go
@@ -19,7 +19,7 @@ func BenchmarkParse(b *testing.B) {
 	b.ReportAllocs()
 	b.SetBytes(int64(len(data)))
 	for b.Loop() {
-		err := Parse(bytes.NewReader(data), func(tss []TimeSerie) {
+		err := Parse(bytes.NewReader(data), false, func(tss []TimeSerie) {
 			cnt += len(tss)
 		})
 		if err != nil {

--- a/app/vmestimator/protoparser/write_request.go
+++ b/app/vmestimator/protoparser/write_request.go
@@ -17,6 +17,10 @@ type TimeSerie struct {
 type Label struct {
 	Name  string
 	Value string
+
+	// Contains fingerprint of Value.
+	// Calculated only if labelFP given to Parse function is true
+	Fingerprint uint64
 }
 
 func getWriteRequestUnmarshaler() *writeRequestUnmarshaler {
@@ -25,7 +29,6 @@ func getWriteRequestUnmarshaler() *writeRequestUnmarshaler {
 		return &writeRequestUnmarshaler{
 			tss:        make([]TimeSerie, 0, 1024),
 			labelsPool: make([]Label, 0, 4096),
-			d:          xxhash.New(),
 		}
 	}
 	return v.(*writeRequestUnmarshaler)
@@ -45,17 +48,15 @@ var wruPool sync.Pool
 type writeRequestUnmarshaler struct {
 	tss        []TimeSerie
 	labelsPool []Label
-	d          *xxhash.Digest
 }
 
 // Reset resets wru, so it could be re-used.
 func (wru *writeRequestUnmarshaler) Reset() {
 	wru.tss = wru.tss[:0]
 	wru.labelsPool = wru.labelsPool[:0]
-	wru.d.Reset()
 }
 
-func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, callback func(tss []TimeSerie)) error {
+func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, labelFP bool, callback func(tss []TimeSerie)) error {
 	wru.Reset()
 
 	var err error
@@ -88,9 +89,7 @@ func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, callback func(
 			}
 			tss = tss[:len(tss)+1]
 			ts := &tss[len(tss)-1]
-			d := wru.d
-			d.Reset()
-			labelsPool, err = ts.unmarshalProtobuf(data, labelsPool, d)
+			labelsPool, err = ts.unmarshalProtobuf(data, labelsPool, labelFP)
 			if err != nil {
 				return fmt.Errorf("cannot unmarshal timeseries: %w", err)
 			}
@@ -105,15 +104,31 @@ func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, callback func(
 
 	wru.tss = tss[:0]
 	wru.labelsPool = labelsPool
-	wru.d.Reset()
 	return nil
 }
 
-func (ts *TimeSerie) unmarshalProtobuf(src []byte, labelsPool []Label, d *xxhash.Digest) ([]Label, error) {
+func (ts *TimeSerie) unmarshalProtobuf(src []byte, labelsPool []Label, labelFP bool) ([]Label, error) {
 	// message TimeSeries {
 	//   repeated Label labels   = 1;
 	//   repeated Sample samples = 2;
 	// }
+
+	tsD := getDigest()
+	defer putDigest(tsD)
+
+	digestLabel := func(value []byte) uint64 {
+		return 0
+	}
+	if labelFP {
+		ld := getDigest()
+		defer putDigest(ld)
+
+		digestLabel = func(value []byte) uint64 {
+			ld.Reset()
+			_, _ = ld.Write(value)
+			return ld.Sum64()
+		}
+	}
 
 	labelsPoolLen := len(labelsPool)
 	var fc easyproto.FieldContext
@@ -152,15 +167,30 @@ func (ts *TimeSerie) unmarshalProtobuf(src []byte, labelsPool []Label, d *xxhash
 				}
 			}
 
-			_, _ = d.Write(data)
-
+			_, _ = tsD.Write(data)
 			labelsPool = append(labelsPool, Label{
-				Name:  bytesutil.ToUnsafeString(nameBytes),
-				Value: bytesutil.ToUnsafeString(valueBytes),
+				Name:        bytesutil.ToUnsafeString(nameBytes),
+				Value:       bytesutil.ToUnsafeString(valueBytes),
+				Fingerprint: digestLabel(valueBytes),
 			})
 		}
 	}
 	ts.Labels = labelsPool[labelsPoolLen:]
-	ts.Fingerprint = d.Sum64()
+	ts.Fingerprint = tsD.Sum64()
 	return labelsPool, nil
+}
+
+func getDigest() *xxhash.Digest {
+	return xxhashPool.Get().(*xxhash.Digest)
+}
+
+func putDigest(d *xxhash.Digest) {
+	d.Reset()
+	xxhashPool.Put(d)
+}
+
+var xxhashPool = &sync.Pool{
+	New: func() any {
+		return xxhash.New()
+	},
 }

--- a/app/vmestimator/protoparser/write_request_timing_test.go
+++ b/app/vmestimator/protoparser/write_request_timing_test.go
@@ -23,7 +23,7 @@ func BenchmarkWriteRequest_UnmarshalProtobuf(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for b.Loop() {
 				wru.Reset()
-				if err := wru.UnmarshalProtobuf(data, func(tss []TimeSerie) {
+				if err := wru.UnmarshalProtobuf(data, false, func(tss []TimeSerie) {
 					cnt += len(tss)
 				}); err != nil {
 					b.Fatalf("unexpected error: %s", err)

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -16,6 +16,8 @@ Metrics of the latest version of vmestimator cluster are available for viewing a
 
 ## tip
 
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add `__label__` pseudo-label for `group_by`. It estimates unique values per label name, making it easy to spot high-cardinality labels like `trace_id` or `user_id`. Can be combined with explicit keys, e.g. `["job", "__label__"]`. See [#26](https://github.com/VictoriaMetrics/vmestimator/issues/26).
+
 ## [v0.1.8](https://github.com/VictoriaMetrics/vmestimator/releases/tag/v0.1.8)
 
 Released at 2026-07-17

--- a/docs/vmestimator/vmestimator.md
+++ b/docs/vmestimator/vmestimator.md
@@ -126,8 +126,13 @@ streams:
     # Omit entirely for a single global estimate across all series.
     # Examples:
     #  - ["job"]
-    #  - ["__name__"] 
+    #  - ["__name__"]
     #  - ["vm_account_id","vm_project_id"]
+    #
+    # The special pseudo-label "__label__" may appear as the last element.
+    # It estimates the number of unique values per label name instead of a whole time series.
+    # Can be combined with explicit keys: ["job", "__label__"] gives unique values per label name, per job.
+    # "__label__" may appear at most once and must be the last element.
     #
     # default: none (single global estimate)
     group_by: '[<string>, ...]'
@@ -192,6 +197,14 @@ cardinality_estimate{interval="5m0s",group_by_keys="instance,job",group_by_value
 cardinality_estimate{interval="5m0s",group_by_keys="instance,job",group_by_values="host2:9100,node",by_instance="host2:9100",by_job="node"} 87
 ```
 
+For `__label__` streams, the group value is the label name and `by__label__` holds it:
+```
+cardinality_estimate{interval="5m0s",group_by_keys="__group__",group_by_values="__label__"} 3
+cardinality_estimate{interval="5m0s",group_by_keys="__label__",group_by_values="__name__",by__label__="__name__"} 450
+cardinality_estimate{interval="5m0s",group_by_keys="__label__",group_by_values="job",by__label__="job"} 12
+cardinality_estimate{interval="5m0s",group_by_keys="__label__",group_by_values="instance",by__label__="instance"} 87
+```
+
 > Note: the total distinct group count in the summary line may exceed the number of per-group lines when `group_limit` is reached
 and excess groups are counted in a single shared "rejected" sketch rather than getting their own entry.
 
@@ -239,6 +252,18 @@ Per tenant cardinality:
 - interval: '5m'
   group_by: ['vm_account_id', 'vm_project_id']
 ```
+
+Per label unique values:
+```yaml
+# streams.yaml
+
+- interval: '5m'
+  group_by: ['__label__']
+```
+
+This estimates the number of unique values for every label name seen in the ingested traffic.
+Useful for identifying high-cardinality labels (e.g. `trace_id`, `user_id`) before they cause storage problems.
+Can be narrowed to a specific job: `['job', '__label__']`.
 
 ### Churn calculation
 


### PR DESCRIPTION
Users can now add `__label__` to `group_by` to get per-label-name
cardinality sketches. Each incoming time series is expanded into one HLL
insert per label it carries, counting unique label values rather than
unique time series. This lets operators identify which label names drive
cardinality spikes across all or a subset of metrics in a single config
entry.

Also validates that `__label__` appears at most once in group_by and
normalises it to the last position so the estimator can always find it
with a single bounds check.

Fixes https://github.com/VictoriaMetrics/vmestimator/issues/26