### PR TITLE
app/vmestimator/protoparser: Ignore cardinality_estimate metrics during ingest

### DIFF
--- a/app/vmestimator/protoparser/streamparser_test.go
+++ b/app/vmestimator/protoparser/streamparser_test.go
@@ -1,0 +1,191 @@
+package protoparser
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/prompb"
+	"github.com/golang/snappy"
+)
+
+func TestParseRequestBody(t *testing.T) {
+	f := func(labelFP bool, input []prompb.TimeSeries, exp []TimeSerie) {
+		t.Helper()
+		pbData := (&prompb.WriteRequest{Timeseries: input}).MarshalProtobuf(nil)
+		data := snappy.Encode(nil, pbData)
+
+		var act []TimeSerie
+		if err := parseRequestBody(data, labelFP, func(batch []TimeSerie) {
+			act = append(act, batch...)
+		}); err != nil {
+			t.Fatalf("parseRequestBody: unexpected error: %s", err)
+		}
+		if !reflect.DeepEqual(exp, act) {
+			t.Fatalf("unexpected time series\nexpected: %v\ngot:      %v", exp, act)
+		}
+	}
+
+	// regular series pass through unchanged
+	f(false,
+		[]prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "requests_total"},
+					{Name: "job", Value: "frontend"},
+					{Name: "foo", Value: "fooVal"},
+				},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "requests_total"},
+					{Name: "job", Value: "backend"},
+					{Name: "bar", Value: "barVal"},
+				},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+			},
+		},
+		[]TimeSerie{
+			{
+				Labels: []Label{
+					{Name: "__name__", Value: "requests_total"},
+					{Name: "job", Value: "frontend"},
+					{Name: "foo", Value: "fooVal"},
+				},
+				Fingerprint: 16911267577736150059,
+			},
+			{
+				Labels: []Label{
+					{Name: "__name__", Value: "requests_total"},
+					{Name: "job", Value: "backend"},
+					{Name: "bar", Value: "barVal"},
+				},
+				Fingerprint: 11849420350211768702,
+			},
+		},
+	)
+
+	// cardinality_estimate is filtered out entirely
+	f(false,
+		[]prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "cardinality_estimate"},
+					{Name: "job", Value: "vmestimator"},
+					{Name: "group_by_keys", Value: "__global__"},
+				},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "requests_total"},
+					{Name: "job", Value: "api"},
+				},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+			},
+		},
+		[]TimeSerie{
+			{
+				Labels: []Label{
+					{Name: "__name__", Value: "requests_total"},
+					{Name: "job", Value: "api"},
+				},
+				Fingerprint: 10041348240829539526,
+			},
+		},
+	)
+
+	// cardinality_estimate is filtered out entirely when labelFP=true
+	f(true,
+		[]prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "cardinality_estimate"},
+					{Name: "job", Value: "vmestimator"},
+					{Name: "group_by_keys", Value: "__global__"},
+				},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "requests_total"},
+					{Name: "job", Value: "api"},
+				},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+			},
+		},
+		[]TimeSerie{
+			{
+				Labels: []Label{
+					{Name: "__name__", Value: "requests_total", Fingerprint: 17112259355248401197},
+					{Name: "job", Value: "api", Fingerprint: 5617089093593724463},
+				},
+				Fingerprint: 10041348240829539526,
+			},
+		},
+	)
+
+	// all cardinality_estimate — result is empty
+	f(false,
+		[]prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "cardinality_estimate"},
+					{Name: "job", Value: "vmestimator"},
+					{Name: "group_by_keys", Value: "__global__"},
+				},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "cardinality_estimate"},
+					{Name: "job", Value: "vmestimator"},
+					{Name: "group_by_keys", Value: "foo"},
+					{Name: "group_by_values", Value: "fooVal"},
+				},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+			},
+		},
+		nil,
+	)
+
+	// label fingerprints are computed when labelFP=true
+	f(true,
+		[]prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "requests_total"},
+					{Name: "job", Value: "api"},
+					{Name: "foo", Value: "fooVal"},
+				},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "up"},
+					{Name: "job", Value: "api"},
+					{Name: "bar", Value: "barVal"},
+				},
+				Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+			},
+		},
+		[]TimeSerie{
+			{
+				Labels: []Label{
+					{Name: "__name__", Value: "requests_total", Fingerprint: 17112259355248401197},
+					{Name: "job", Value: "api", Fingerprint: 5617089093593724463},
+					{Name: "foo", Value: "fooVal", Fingerprint: 18265805195628551540},
+				},
+				Fingerprint: 11009355061427964546,
+			},
+			{
+				Labels: []Label{
+					{Name: "__name__", Value: "up", Fingerprint: 2571373012096355983},
+					{Name: "job", Value: "api", Fingerprint: 5617089093593724463},
+					{Name: "bar", Value: "barVal", Fingerprint: 3223421134637281647},
+				},
+				Fingerprint: 14808323381317661148,
+			},
+		},
+	)
+}

--- a/app/vmestimator/protoparser/write_request.go
+++ b/app/vmestimator/protoparser/write_request.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 )
 
-var skipTs = errors.New("skip time series")
+var errSkipTs = errors.New("skip time series")
 
 type TimeSerie struct {
 	Labels      []Label
@@ -93,7 +93,7 @@ func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, labelFP bool, 
 			tss = tss[:len(tss)+1]
 			ts := &tss[len(tss)-1]
 			labelsPool, err = ts.unmarshalProtobuf(data, labelsPool, labelFP)
-			if errors.Is(err, skipTs) {
+			if errors.Is(err, errSkipTs) {
 				tss = tss[:len(tss)-1]
 			} else if err != nil {
 				return fmt.Errorf("cannot unmarshal timeseries: %w", err)
@@ -178,7 +178,7 @@ func (ts *TimeSerie) unmarshalProtobuf(src []byte, labelsPool []Label, labelFP b
 			// Skip cardinality_estimate metrics — estimating the estimator's own output adds noise without value.
 			// See https://github.com/VictoriaMetrics/vmestimator/issues/30
 			if name == `__name__` && value == `cardinality_estimate` {
-				return labelsPool[:labelsPoolLen], skipTs
+				return labelsPool[:labelsPoolLen], errSkipTs
 			}
 
 			_, _ = tsD.Write(data)

--- a/app/vmestimator/protoparser/write_request.go
+++ b/app/vmestimator/protoparser/write_request.go
@@ -1,6 +1,7 @@
 package protoparser
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -8,6 +9,8 @@ import (
 	"github.com/VictoriaMetrics/easyproto"
 	"github.com/cespare/xxhash/v2"
 )
+
+var skipTs = errors.New("skip time series")
 
 type TimeSerie struct {
 	Labels      []Label
@@ -90,7 +93,9 @@ func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, labelFP bool, 
 			tss = tss[:len(tss)+1]
 			ts := &tss[len(tss)-1]
 			labelsPool, err = ts.unmarshalProtobuf(data, labelsPool, labelFP)
-			if err != nil {
+			if errors.Is(err, skipTs) {
+				tss = tss[:len(tss)-1]
+			} else if err != nil {
 				return fmt.Errorf("cannot unmarshal timeseries: %w", err)
 			}
 		}
@@ -167,10 +172,19 @@ func (ts *TimeSerie) unmarshalProtobuf(src []byte, labelsPool []Label, labelFP b
 				}
 			}
 
+			name := bytesutil.ToUnsafeString(nameBytes)
+			value := bytesutil.ToUnsafeString(valueBytes)
+
+			// Skip cardinality_estimate metrics — estimating the estimator's own output adds noise without value.
+			// See https://github.com/VictoriaMetrics/vmestimator/issues/30
+			if name == `__name__` && value == `cardinality_estimate` {
+				return labelsPool[:labelsPoolLen], skipTs
+			}
+
 			_, _ = tsD.Write(data)
 			labelsPool = append(labelsPool, Label{
-				Name:        bytesutil.ToUnsafeString(nameBytes),
-				Value:       bytesutil.ToUnsafeString(valueBytes),
+				Name:        name,
+				Value:       value,
 				Fingerprint: digestLabel(valueBytes),
 			})
 		}

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -16,6 +16,8 @@ Metrics of the latest version of vmestimator cluster are available for viewing a
 
 ## tip
 
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): ignore cardinality_estimate metrics during ingest. See [#30](https://github.com/VictoriaMetrics/vmestimator/issues/30).
+
 ## [v0.1.9](https://github.com/VictoriaMetrics/vmestimator/releases/tag/v0.1.9)
 
 Released at 2026-08-03


### PR DESCRIPTION
vmestimator exponse cardinality_estimate metrics at /metrics by default.
If those metrics are scraped by the same vmagent that pushes metrics for
estimation, vmestimator would estimate its own output - producing noise
with no practical value.

Drop such series at parse time before they reach the estimation
pipeline.

Fixes https://github.com/VictoriaMetrics/vmestimator/issues/30