### PR TITLE
app/vmestimator: reuse HLL sketches from prevGroup 

### DIFF
--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -440,15 +440,13 @@ func (eb *estimatorBucket) insert(fp uint64, groupValuesKey string, groupValues 
 
 	gsk, ok := eb.groups[groupValuesKey]
 	if !ok {
-		prevGSK, ok := eb.prevGroups[groupValuesKey]
-		if !ok {
+		var groupValueLabels string
+		var sk *hyperloglog.Sketch
+		if prevGSK, ok := eb.prevGroups[groupValuesKey]; !ok {
 			if !eb.groupSize.allowInsertLocked(eb.idx, groupValuesKey) {
 				return
 			}
-		}
 
-		groupValueLabels := prevGSK.groupValueLabels
-		if len(groupValueLabels) == 0 {
 			formatBuf := make([]byte, 0, 1024)
 			formatBuf = strconv.AppendQuote(formatBuf, groupValuesKey)
 			for i := range groupValues {
@@ -468,12 +466,18 @@ func (eb *estimatorBucket) insert(fp uint64, groupValuesKey string, groupValues 
 			formatBuf = append(formatBuf, `} `...)
 
 			groupValueLabels = bytesutil.ToUnsafeString(formatBuf)
+			sk = eb.newSketch()
+		} else {
+			groupValueLabels = prevGSK.groupValueLabels
+
+			sk = prevGSK.Sketch
+			sk.Reset()
+			delete(eb.prevGroups, groupValuesKey)
 		}
 
 		gsk = groupSketch{
 			groupValueLabels: groupValueLabels,
-
-			Sketch: eb.newSketch(),
+			Sketch:           sk,
 		}
 
 		eb.groups[strings.Clone(groupValuesKey)] = gsk

--- a/app/vmestimator/estimator_timing_test.go
+++ b/app/vmestimator/estimator_timing_test.go
@@ -218,11 +218,11 @@ func BenchmarkEstimator_InsertManyParallel(b *testing.B) {
 }
 
 // BenchmarkEstimator_InsertRotateCycle benchmarks the insert→rotate→insert cycle
-// for the global (no-group) estimator in two HLL regimes:
+// in two HLL regimes (sparse/normal) and two grouping modes (no-group/grouped).
 //   - Sparse: 1 000 series per interval (sketch stays in sparse mode)
 //   - Normal: 30 000 series per interval (sketch converts to dense mode)
 func BenchmarkEstimator_InsertRotateCycle(b *testing.B) {
-	b.Run("SparseHLL", func(b *testing.B) {
+	b.Run("NoGroup/SparseHLL", func(b *testing.B) {
 		e, err := newEstimator(EstimatorConfig{Interval: time.Hour})
 		if err != nil {
 			b.Fatalf("newEstimator: %v", err)
@@ -239,7 +239,7 @@ func BenchmarkEstimator_InsertRotateCycle(b *testing.B) {
 		}
 	})
 
-	b.Run("NormalHLL", func(b *testing.B) {
+	b.Run("NoGroup/NormalHLL", func(b *testing.B) {
 		e, err := newEstimator(EstimatorConfig{Interval: time.Hour})
 		if err != nil {
 			b.Fatalf("newEstimator: %v", err)
@@ -250,6 +250,46 @@ func BenchmarkEstimator_InsertRotateCycle(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			insertSeriesIntoEstimator(e, 30_000, 0)
+			for i := range e.buckets {
+				e.buckets[i].rotate()
+			}
+		}
+	})
+
+	b.Run("Group100/SparseHLL", func(b *testing.B) {
+		e, err := newEstimator(EstimatorConfig{
+			GroupBy:  []string{"groupLabel"},
+			Interval: time.Hour,
+		})
+		if err != nil {
+			b.Fatalf("newEstimator: %v", err)
+		}
+		defer e.stop()
+
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			insertSeriesIntoEstimator(e, 1_000, 100)
+			for i := range e.buckets {
+				e.buckets[i].rotate()
+			}
+		}
+	})
+
+	b.Run("Group100/NormalHLL", func(b *testing.B) {
+		e, err := newEstimator(EstimatorConfig{
+			GroupBy:  []string{"groupLabel"},
+			Interval: time.Hour,
+		})
+		if err != nil {
+			b.Fatalf("newEstimator: %v", err)
+		}
+		defer e.stop()
+
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			insertSeriesIntoEstimator(e, 30_000, 100)
 			for i := range e.buckets {
 				e.buckets[i].rotate()
 			}

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -16,6 +16,8 @@ Metrics of the latest version of vmestimator cluster are available for viewing a
 
 ## tip
 
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): Reduce memory presure on rotation by reusing HLL sketches from previous group. 
+
 ## [v0.1.9](https://github.com/VictoriaMetrics/vmestimator/releases/tag/v0.1.9)
 
 Released at 2026-08-03


### PR DESCRIPTION
```
                                                  │ base.bench  │             reuse.bench              │
                                                  │   sec/op    │    sec/op     vs base                │
Estimator_InsertRotateCycle/NoGroup/SparseHLL-10    120.6µ ± 1%   119.1µ ±  1%   -1.29% (p=0.001 n=10)
Estimator_InsertRotateCycle/NoGroup/NormalHLL-10    5.476m ± 4%   5.510m ±  2%        ~ (p=0.436 n=10)
Estimator_InsertRotateCycle/Group100/SparseHLL-10   258.4µ ± 1%   225.4µ ±  1%  -12.80% (p=0.000 n=10)
Estimator_InsertRotateCycle/Group100/NormalHLL-10   7.491m ± 0%   7.241m ±  1%   -3.34% (p=0.000 n=10)
geomean                                             73.10µ        69.61µ         -4.77%
                                                  │   base.bench    │               reuse.bench               │
                                                  │      B/op       │     B/op       vs base                  │
Estimator_InsertRotateCycle/NoGroup/SparseHLL-10     47.59Ki ± 0%      47.59Ki ± 0%        ~ (p=1.000 n=10) ¹
Estimator_InsertRotateCycle/NoGroup/NormalHLL-10    1008.9Ki ± 0%     1008.9Ki ± 0%        ~ (p=0.986 n=10)
Estimator_InsertRotateCycle/Group100/SparseHLL-10   133.76Ki ± 0%      82.22Ki ± 0%  -38.53% (p=0.000 n=10)
Estimator_InsertRotateCycle/Group100/NormalHLL-10    2.645Mi ± 0%      2.340Mi ± 0%  -11.53% (p=0.000 n=10)
geomean                                                           ²                   -4.61%
```