### PR TITLE
Docs: Add SEO meta description

### DIFF
--- a/docs/vmestimator/_index.md
+++ b/docs/vmestimator/_index.md
@@ -5,6 +5,7 @@ menu:
     parent: victoriametrics
     weight: 12
 title: vmestimator
+description: "Tool for real-time cardinality tracking. Supports custom configuration and exposes cardinality observations in form of metrics."
 tags:
   - metrics
   - cardinality


### PR DESCRIPTION
This PR add meta descriptions to every page in the docs in this repository. Right now, we have one general meta description for every page. This PR adds page-specific descriptions.

Meta descriptions are not likely to improve rankings on search engines but can improve CTRs. They can also be used to keep LLMs.txt updated as new pages are added (by adding an automation later).

The descriptions were taken from LLMs.txt, so they were already reviewed in https://github.com/VictoriaMetrics/vmdocs/pull/251
I only tweaked those that needed trimming to fit into the 160 SEO character limit. We also revised them with our SEO specialist (Jonathan). So I think it's a good staring point.

I'm going to open a PR for every repository that contributes to the docs and add descriptions so eventually every page in the docs has a dedicated meta descriptions.