### PR TITLE
app/vmestimator: split incoming time series among pool of workers

### DIFF
--- a/app/vmestimator/main.go
+++ b/app/vmestimator/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/buildinfo"
@@ -42,14 +43,16 @@ func main() {
 		logger.Fatalf("cannot load config: %v", err)
 	}
 
-	var labelFP bool
 	for _, e := range es {
 		for _, l := range e.groupBy {
 			if l == labelKeyword {
-				labelFP = true
+				protoparser.SetFingerprintLabels(true)
 			}
 		}
 	}
+
+	startWorkers()
+	defer stopWorkers()
 
 	if *cardinalityMetricsExposeAt == `/metrics` {
 		metrics.RegisterMetricsWriter(func(w io.Writer) {
@@ -77,13 +80,32 @@ func main() {
 		switch path {
 		case "/api/v1/write":
 			prometheusWriteRequests.Inc()
-			err := protoparser.Parse(r.Body, labelFP, func(tss []protoparser.TimeSerie) {
+			err := protoparser.Parse(r.Body, func(tss []protoparser.TimeSerie) {
+				const chunkSize = 100
 				esLen := uint32(len(es))
-				start := fastrand.Uint32n(esLen)
-				for j := uint32(0); j < esLen; j++ {
-					i := (start + j) % esLen
-					es[i].insertMany(tss)
+				wg := &sync.WaitGroup{}
+			loop:
+				for start := 0; start < len(tss); start += chunkSize {
+					end := start + chunkSize
+					if end > len(tss) {
+						end = len(tss)
+					}
+					tssChunk := tss[start:end]
+
+					esStart := fastrand.Uint32n(esLen)
+
+					for j := uint32(0); j < esLen; j++ {
+						idx := (esStart + j) % esLen
+						wg.Add(1)
+						select {
+						case workersCh <- workerReq{e: es[idx], wg: wg, tss: tssChunk}:
+						case <-r.Context().Done():
+							wg.Done()
+							break loop
+						}
+					}
 				}
+				wg.Wait()
 			})
 			if err != nil {
 				httpserver.Errorf(w, r, "error parsing remote write request: %s", err)

--- a/app/vmestimator/protoparser/streamparser.go
+++ b/app/vmestimator/protoparser/streamparser.go
@@ -18,12 +18,12 @@ var maxInsertRequestSize = flagutil.NewBytes("maxInsertRequestSize", 32*1024*102
 // Parse parses Prometheus remote_write message from reader and calls callback for the parsed timeseries.
 //
 // callback shouldn't hold tss after returning.
-func Parse(r io.Reader, labelFP bool, callback func(tss []TimeSerie)) error {
+func Parse(r io.Reader, callback func(tss []TimeSerie)) error {
 	startTime := fasttime.UnixTimestamp()
 
 	readCalls.Inc()
 	err := protoparserutil.ReadUncompressedData(r, "", maxInsertRequestSize, func(data []byte) error {
-		return parseRequestBody(data, labelFP, callback) //nolint:unparam
+		return parseRequestBody(data, callback) //nolint:unparam
 	})
 	if err != nil {
 		readErrors.Inc()
@@ -32,7 +32,7 @@ func Parse(r io.Reader, labelFP bool, callback func(tss []TimeSerie)) error {
 	return nil
 }
 
-func parseRequestBody(data []byte, labelFP bool, callback func(tss []TimeSerie)) error {
+func parseRequestBody(data []byte, cb func(tss []TimeSerie)) error {
 	// Synchronously process the request in order to properly return errors to Parse caller,
 	// so it could properly return HTTP 503 status code in response.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/896
@@ -57,12 +57,15 @@ func parseRequestBody(data []byte, labelFP bool, callback func(tss []TimeSerie))
 	}
 	wru := getWriteRequestUnmarshaler()
 	defer putWriteRequestUnmarshaler(wru)
-	if err := wru.UnmarshalProtobuf(bb.B, labelFP, func(tss []TimeSerie) {
-		rowsRead.Add(len(tss))
-		callback(tss)
-	}); err != nil {
+	wr, err := wru.UnmarshalProtobuf(bb.B)
+	if err != nil {
 		unmarshalErrors.Inc()
 		return fmt.Errorf("cannot unmarshal prompb.WriteRequest with size %d bytes: %w", len(bb.B), err)
+	}
+
+	if len(wr.Timeseries) > 0 {
+		rowsRead.Add(len(wr.Timeseries))
+		cb(wr.Timeseries)
 	}
 
 	return nil

--- a/app/vmestimator/protoparser/streamparser_test.go
+++ b/app/vmestimator/protoparser/streamparser_test.go
@@ -9,14 +9,25 @@ import (
 )
 
 func TestParseRequestBody(t *testing.T) {
-	f := func(labelFP bool, input []prompb.TimeSeries, exp []TimeSerie) {
+	originalFPLabels := fpLabelsGlobal.Load()
+	t.Cleanup(func() {
+		fpLabelsGlobal.Store(originalFPLabels)
+	})
+
+	f := func(fpLabels bool, input []prompb.TimeSeries, exp []TimeSerie) {
 		t.Helper()
 		pbData := (&prompb.WriteRequest{Timeseries: input}).MarshalProtobuf(nil)
 		data := snappy.Encode(nil, pbData)
 
+		SetFingerprintLabels(fpLabels)
+
 		var act []TimeSerie
-		if err := parseRequestBody(data, labelFP, func(batch []TimeSerie) {
-			act = append(act, batch...)
+		if err := parseRequestBody(data, func(batch []TimeSerie) {
+			for _, ts := range batch {
+				labels := make([]Label, len(ts.Labels))
+				copy(labels, ts.Labels)
+				act = append(act, TimeSerie{Labels: labels, Fingerprint: ts.Fingerprint})
+			}
 		}); err != nil {
 			t.Fatalf("parseRequestBody: unexpected error: %s", err)
 		}

--- a/app/vmestimator/protoparser/streamparser_timing_test.go
+++ b/app/vmestimator/protoparser/streamparser_timing_test.go
@@ -19,7 +19,7 @@ func BenchmarkParse(b *testing.B) {
 	b.ReportAllocs()
 	b.SetBytes(int64(len(data)))
 	for b.Loop() {
-		err := Parse(bytes.NewReader(data), false, func(tss []TimeSerie) {
+		err := Parse(bytes.NewReader(data), func(tss []TimeSerie) {
 			cnt += len(tss)
 		})
 		if err != nil {

--- a/app/vmestimator/protoparser/write_request.go
+++ b/app/vmestimator/protoparser/write_request.go
@@ -3,6 +3,7 @@ package protoparser
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
 	"github.com/VictoriaMetrics/easyproto"
@@ -23,11 +24,20 @@ type Label struct {
 	Fingerprint uint64
 }
 
+type WriteRequest struct {
+	// Timeseries is a list of time series in the given WriteRequest
+	Timeseries []TimeSerie
+}
+
+// Reset resets wr for subsequent reuse.
+func (wr *WriteRequest) Reset() {
+	wr.Timeseries = ResetTimeSeries(wr.Timeseries)
+}
+
 func getWriteRequestUnmarshaler() *writeRequestUnmarshaler {
 	v := wruPool.Get()
 	if v == nil {
 		return &writeRequestUnmarshaler{
-			tss:        make([]TimeSerie, 0, 1024),
 			labelsPool: make([]Label, 0, 4096),
 		}
 	}
@@ -46,68 +56,63 @@ var wruPool sync.Pool
 // It maintains internal pools for labels and samples to reduce memory allocations.
 // See UnmarshalProtobuf for details on how to use it.
 type writeRequestUnmarshaler struct {
-	tss        []TimeSerie
+	wr WriteRequest
+
 	labelsPool []Label
 }
 
 // Reset resets wru, so it could be re-used.
 func (wru *writeRequestUnmarshaler) Reset() {
-	wru.tss = wru.tss[:0]
+	wru.wr.Reset()
+
+	clear(wru.labelsPool)
 	wru.labelsPool = wru.labelsPool[:0]
 }
 
-func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte, labelFP bool, callback func(tss []TimeSerie)) error {
+func (wru *writeRequestUnmarshaler) UnmarshalProtobuf(src []byte) (*WriteRequest, error) {
 	wru.Reset()
 
-	var err error
+	fpLabels := fpLabelsGlobal.Load()
 
-	tss := wru.tss
+	var err error
 
 	// message WriteRequest {
 	//    repeated TimeSeries timeseries = 1;
 	//    reserved 2;
 	//    repeated Metadata metadata = 3;
 	// }
+	tss := wru.wr.Timeseries
 	labelsPool := wru.labelsPool
 	var fc easyproto.FieldContext
 	for len(src) > 0 {
-		if len(tss) >= cap(tss) {
-			callback(tss)
-			tss = tss[:0]
-			labelsPool = labelsPool[:0]
-		}
-
 		src, err = fc.NextField(src)
 		if err != nil {
-			return fmt.Errorf("cannot read the next field: %w", err)
+			return nil, fmt.Errorf("cannot read the next field: %w", err)
 		}
 		switch fc.FieldNum {
 		case 1:
 			data, ok := fc.MessageData()
 			if !ok {
-				return fmt.Errorf("cannot read timeseries data")
+				return nil, fmt.Errorf("cannot read timeseries data")
 			}
-			tss = tss[:len(tss)+1]
+			if len(tss) < cap(tss) {
+				tss = tss[:len(tss)+1]
+			} else {
+				tss = append(tss, TimeSerie{})
+			}
 			ts := &tss[len(tss)-1]
-			labelsPool, err = ts.unmarshalProtobuf(data, labelsPool, labelFP)
+			labelsPool, err = ts.unmarshalProtobuf(data, labelsPool, fpLabels)
 			if err != nil {
-				return fmt.Errorf("cannot unmarshal timeseries: %w", err)
+				return nil, fmt.Errorf("cannot unmarshal timeseries: %w", err)
 			}
 		}
 	}
-
-	if len(tss) > 0 {
-		callback(tss)
-		tss = tss[:0]
-		labelsPool = labelsPool[:0]
-	}
-
-	wru.tss = tss[:0]
+	wru.wr.Timeseries = tss
 	wru.labelsPool = labelsPool
-	return nil
+	return &wru.wr, nil
 }
 
-func (ts *TimeSerie) unmarshalProtobuf(src []byte, labelsPool []Label, labelFP bool) ([]Label, error) {
+func (ts *TimeSerie) unmarshalProtobuf(src []byte, labelsPool []Label, fpLabels bool) ([]Label, error) {
 	// message TimeSeries {
 	//   repeated Label labels   = 1;
 	//   repeated Sample samples = 2;
@@ -119,7 +124,7 @@ func (ts *TimeSerie) unmarshalProtobuf(src []byte, labelsPool []Label, labelFP b
 	digestLabel := func(value []byte) uint64 {
 		return 0
 	}
-	if labelFP {
+	if fpLabels {
 		ld := getDigest()
 		defer putDigest(ld)
 
@@ -193,4 +198,16 @@ var xxhashPool = &sync.Pool{
 	New: func() any {
 		return xxhash.New()
 	},
+}
+
+var fpLabelsGlobal atomic.Bool
+
+func SetFingerprintLabels(b bool) {
+	fpLabelsGlobal.Store(b)
+}
+
+// ResetTimeSeries clears all the GC references from tss and returns an empty tss ready for further use.
+func ResetTimeSeries(tss []TimeSerie) []TimeSerie {
+	clear(tss)
+	return tss[:0]
 }

--- a/app/vmestimator/protoparser/write_request_timing_test.go
+++ b/app/vmestimator/protoparser/write_request_timing_test.go
@@ -23,11 +23,11 @@ func BenchmarkWriteRequest_UnmarshalProtobuf(b *testing.B) {
 			b.SetBytes(int64(len(data)))
 			for b.Loop() {
 				wru.Reset()
-				if err := wru.UnmarshalProtobuf(data, false, func(tss []TimeSerie) {
-					cnt += len(tss)
-				}); err != nil {
+				wr, err := wru.UnmarshalProtobuf(data)
+				if err != nil {
 					b.Fatalf("unexpected error: %s", err)
 				}
+				cnt += len(wr.Timeseries)
 			}
 		})
 	}

--- a/app/vmestimator/workers.go
+++ b/app/vmestimator/workers.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"flag"
+	"sync"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/cgroup"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser"
+)
+
+var (
+	workers   = flag.Int(`workers`, max(1, cgroup.AvailableCPUs()*2), `The number of workers for processing time series insertions concurrently. Each worker handles insertMany calls for a single estimator. Defaults to 2x the number of available CPUs.`)
+	workersCh chan workerReq
+	workersWG sync.WaitGroup
+)
+
+func startWorkers() {
+	if *workers < 1 {
+		logger.Fatalf("BUG: -workers must be at least 1, got %d", *workers)
+	}
+
+	workersCh = make(chan workerReq, *workers*2)
+
+	for i := 0; i < *workers; i++ {
+		workersWG.Go(func() {
+			for req := range workersCh {
+				e, wg, tss := req.e, req.wg, req.tss
+
+				e.insertMany(tss)
+				wg.Done()
+			}
+		})
+	}
+}
+
+func stopWorkers() {
+	close(workersCh)
+	workersWG.Wait()
+	workersCh = nil
+}
+
+type workerReq struct {
+	e   *estimator
+	wg  *sync.WaitGroup
+	tss []protoparser.TimeSerie
+}

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -16,6 +16,8 @@ Metrics of the latest version of vmestimator cluster are available for viewing a
 
 ## tip
 
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add `-workers` flag for processing time series insertions concurrently. This improves throughput under high ingestion load. See [#42](https://github.com/VictoriaMetrics/vmestimator/pull/42).
+
 ## [v0.1.13](https://github.com/VictoriaMetrics/vmestimator/releases/tag/v0.1.13)
 
 * FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add `-cardinalityMetrics.minCardinality` flag to suppress group-by cardinality estimates below the given threshold. When estimates are filtered, the number of suppressed groups is exposed via the `vmestimator_cardinality_estimates_dropped` metric. See [#41](https://github.com/VictoriaMetrics/vmestimator/pull/41).

--- a/docs/vmestimator/vmestimator.md
+++ b/docs/vmestimator/vmestimator.md
@@ -509,9 +509,9 @@ Usage of ./bin/vmestimator:
   -cardinalityMetrics.exposeAt string
         HTTP path for exposing cardinality metrics. If set to the default /metrics, cardinality metrics are merged with regular metrics and exposed together. If set to a different path, only cardinality metrics are exposed at that endpoint. If set to an empty value, cardinality metrics are not exposed via HTTP at all. (default "/metrics")
   -cardinalityMetrics.minCardinality uint
-        Minimum cardinality estimate to expose for group-by streams. Estimates below this threshold are suppressed to reduce metric volume and noise. Set to 0 to expose all estimates (default 0).
+        Minimum cardinality estimate to expose. Estimates below this threshold are suppressed to reduce metric volume and noise. Set to 0 to expose all estimates (default 0).
   -config string
-        Path to YAML configuration file. Must be set unless -storageNode is specified. See https://github.com/VictoriaMetrics/cestimator/blob/main/streams.yaml for config example
+        Path to YAML configuration file. Must be set unless -storageNode is specified. See https://github.com/VictoriaMetrics/vmestimator/blob/main/streams.yaml for config example
   -enableTCP6
         Whether to enable IPv6 for listening and dialing. By default, only IPv4 TCP and UDP are used
   -envflag.enable
@@ -545,7 +545,7 @@ Usage of ./bin/vmestimator:
   -http.idleConnTimeout duration
         Timeout for incoming idle http connections (default 1m0s)
   -http.maxGracefulShutdownDuration duration
-        The maximum duration for a graceful shutdown of the HTTP server. A highly loaded server may require increased value for a graceful shutdown (default 7s)
+        The maximum duration for a graceful shutdown of the HTTP server. During this period the server stops accepting new connections, but it will continue serving existing connections. The remaining in-flight requests are canceled before the deadline, so the shutdown can finish within this duration. A highly loaded server may require increased value for a graceful shutdown (default 7s)
   -http.pathPrefix string
         An optional prefix to add to all the paths handled by http server. For example, if '-http.pathPrefix=/foo/bar' is set, then all the http requests will be handled on '/foo/bar/*' paths. This may be useful for proxied requests. See https://www.robustperception.io/using-external-urls-and-proxies-with-prometheus
   -http.shutdownDelay duration
@@ -652,4 +652,6 @@ Usage of ./bin/vmestimator:
         Each array item can contain comma inside single-quoted or double-quoted string, {}, [] and () braces.
   -version
         Show VictoriaMetrics version
+  -workers int
+        The number of workers for processing time series insertions concurrently. Each worker handles insertMany calls for a single estimator. Defaults to 2x the number of available CPUs. (default 20)
 ```


### PR DESCRIPTION
Previously, `e.insertMany` was called sequentially for each estimator on
every incoming request, becoming a bottleneck under high ingestion load.

Introduce a configurable worker pool (default: 2×CPU, -workers flag)
that processes insertMany calls concurrently. Incoming time series are
split into 100-element chunks, dispatched to estimators via a buffered
channel, and the request waits for all chunks to finish. Context
cancellation is respected.

To enable this, refactor protoparser.UnmarshalProtobuf from a streaming
callback API to returning a *WriteRequest with all unmarshalled time
series. This allows the handler to distribute data across workers before
any insertions begin.

Move the fpLabels option out of the parse call stack into a global
atomic.Bool (SetFingerprintLabels), set once at startup.