### PR TITLE
[EXPERIMENTAL] Add hierarchical estimator support for derived streams

### DIFF
--- a/app/vmestimator/config.go
+++ b/app/vmestimator/config.go
@@ -27,6 +27,12 @@ type EstimatorConfig struct {
 	Buckets      int               `yaml:"buckets"`
 	HLLPrecision uint8             `yaml:"hll_precision"`
 	HLLSparse    *bool             `yaml:"hll_sparse"`
+
+	// DeriveFrom is the index of the base stream to derive estimates from
+	// instead of maintaining its own HLL sketches. nil (default) means the
+	// stream is independent. The derived stream's group_by must be a subset
+	// of the base stream's group_by, and the interval and filter must match.
+	DeriveFrom *int `yaml:"derive_from"`
 }
 
 func loadConfig(path string) ([]*estimator, error) {
@@ -90,6 +96,51 @@ func loadConfig(path string) ([]*estimator, error) {
 			logger.Fatalf("cannot create estimator: %v", err)
 		}
 		es = append(es, e)
+	}
+
+	// Wire up derived estimators.
+	for i, e := range es {
+		if cfg.Streams[i].DeriveFrom == nil {
+			continue
+		}
+
+		baseIdx := *cfg.Streams[i].DeriveFrom
+		if baseIdx >= len(es) {
+			return nil, fmt.Errorf("derive_from index %d out of range for stream %d (have %d streams)", baseIdx, i, len(es))
+		}
+		if baseIdx == i {
+			return nil, fmt.Errorf("stream %d cannot derive from itself", i)
+		}
+
+		base := es[baseIdx]
+		if len(base.groupBy) == 0 {
+			return nil, fmt.Errorf("stream %d derives from stream %d which has no group_by", i, baseIdx)
+		}
+		if cfg.Streams[i].Interval != cfg.Streams[baseIdx].Interval {
+			return nil, fmt.Errorf("derived stream %d must have same interval as base stream %d", i, baseIdx)
+		}
+		if cfg.Streams[i].Filter != cfg.Streams[baseIdx].Filter {
+			return nil, fmt.Errorf("derived stream %d must have same filter as base stream %d", i, baseIdx)
+		}
+		if cfg.Streams[i].HLLPrecision != cfg.Streams[baseIdx].HLLPrecision {
+			return nil, fmt.Errorf("derived stream %d must have same hll_precision as base stream %d", i, baseIdx)
+		}
+
+		di, err := newDerivedInfo(base, e, cfg.Streams[baseIdx])
+		if err != nil {
+			return nil, fmt.Errorf("derived stream %d: %w", i, err)
+		}
+		e.derived = di
+		base.baseFor = append(base.baseFor, e)
+	}
+
+	// Propagate baseFor to buckets so the insert path can notify derived estimators.
+	for _, e := range es {
+		if len(e.baseFor) > 0 {
+			for _, b := range e.buckets {
+				b.baseFor = e.baseFor
+			}
+		}
 	}
 
 	return es, nil

--- a/app/vmestimator/derived_estimator.go
+++ b/app/vmestimator/derived_estimator.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"sync"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/axiomhq/hyperloglog"
+)
+
+// derivedInfo holds the state for an estimator that derives its cardinality
+// estimates from a more granular "base" estimator instead of maintaining its
+// own HLL sketches.
+//
+// At insert time, the base estimator calls insertRejected for fingerprints
+// that were dropped due to group_limit. The derived estimator stores these
+// in per-bucket reject HLLs keyed by the parent group values (the subset of
+// the base group values that corresponds to the derived group_by keys).
+//
+// At snapshot time, the derived estimator sums the base's per-group
+// estimates by parent group, adds the reject HLL estimates, and emits the
+// result as cardinality_estimate metrics.
+type derivedInfo struct {
+	base *estimator
+
+	// parentToBase maps derived group_by key indices to base group_by key
+	// indices. For example, if the base groups by [__name__, region, task_name]
+	// and the derived groups by [__name__, region], then parentToBase = [0, 1].
+	parentToBase []int
+
+	precision uint8
+
+	rejectMu       sync.Mutex
+	rejectSketches []map[uint64]*hyperloglog.Sketch
+	rejectValues   []map[uint64][]string
+}
+
+func newDerivedInfo(base, derived *estimator, baseCfg EstimatorConfig) (*derivedInfo, error) {
+	parentToBase, err := buildParentToBase(derived.groupBy, base.groupBy)
+	if err != nil {
+		return nil, err
+	}
+
+	nBuckets := len(base.buckets)
+	return &derivedInfo{
+		base:           base,
+		parentToBase:   parentToBase,
+		precision:      baseCfg.HLLPrecision,
+		rejectSketches: make([]map[uint64]*hyperloglog.Sketch, nBuckets),
+		rejectValues:   make([]map[uint64][]string, nBuckets),
+	}, nil
+}
+
+// buildParentToBase validates that every key in parentGroupBy exists in
+// baseGroupBy and returns the index mapping.
+func buildParentToBase(parentGroupBy, baseGroupBy []string) ([]int, error) {
+	for _, k := range parentGroupBy {
+		if k == labelKeyword {
+			return nil, fmt.Errorf("__label__ is not supported in derived estimators")
+		}
+	}
+	for _, k := range baseGroupBy {
+		if k == labelKeyword {
+			return nil, fmt.Errorf("__label__ is not supported in base estimators with derived streams")
+		}
+	}
+
+	parentToBase := make([]int, len(parentGroupBy))
+	for i, parentKey := range parentGroupBy {
+		found := false
+		for j, baseKey := range baseGroupBy {
+			if parentKey == baseKey {
+				parentToBase[i] = j
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("group_by key %q in derived stream not found in base stream", parentKey)
+		}
+	}
+	return parentToBase, nil
+}
+
+// insertRejected is called by the base estimator when a child group is
+// rejected due to group_limit. The fingerprint is inserted into a per-bucket
+// reject HLL keyed by the parent group values, so it is still counted in the
+// derived estimate.
+func (di *derivedInfo) insertRejected(bucketIdx int, baseGroupValues []string, fp uint64) {
+	parentValues := di.extractParentValues(baseGroupValues)
+	parentKey := hashGroupValues(parentValues)
+
+	di.rejectMu.Lock()
+	defer di.rejectMu.Unlock()
+
+	sketches := di.rejectSketches[bucketIdx]
+	if sketches == nil {
+		sketches = make(map[uint64]*hyperloglog.Sketch)
+		di.rejectSketches[bucketIdx] = sketches
+	}
+	sk := sketches[parentKey]
+	if sk == nil {
+		sk = mustNewSketch(di.precision, true)
+		sketches[parentKey] = sk
+	}
+	sk.InsertHash(fp)
+
+	values := di.rejectValues[bucketIdx]
+	if values == nil {
+		values = make(map[uint64][]string)
+		di.rejectValues[bucketIdx] = values
+	}
+	if _, ok := values[parentKey]; !ok {
+		values[parentKey] = append([]string{}, parentValues...)
+	}
+}
+
+// extractParentValues picks the subset of baseGroupValues that corresponds
+// to the derived group_by keys, using the parentToBase index mapping.
+func (di *derivedInfo) extractParentValues(baseGroupValues []string) []string {
+	if len(di.parentToBase) == 0 {
+		return nil
+	}
+	parentValues := make([]string, len(di.parentToBase))
+	for i, baseIdx := range di.parentToBase {
+		parentValues[i] = baseGroupValues[baseIdx]
+	}
+	return parentValues
+}
+
+// hashGroupValues computes a uint64 hash of group values using the same
+// digest format as insertMany: "\u0000" + val1 + "\u0000" + val2 + ...
+func hashGroupValues(values []string) uint64 {
+	d := getDigest()
+	defer putDigest(d)
+	for _, v := range values {
+		_, _ = d.WriteString("\u0000")
+		_, _ = d.WriteString(v)
+	}
+	return d.Sum64()
+}
+
+// parentSum accumulates the summed estimate for a single parent group.
+type parentSum struct {
+	values []string
+	sum    uint64
+}
+
+// writeDerivedMetrics derives cardinality estimates from the base estimator
+// and writes them as cardinality_estimate metrics.
+func (e *estimator) writeDerivedMetrics(w io.Writer) {
+	di := e.derived
+	base := di.base
+
+	// Accumulate summed estimates by parent group key.
+	sums := make(map[uint64]*parentSum)
+
+	// 1. Sum base estimator's per-group estimates by parent group.
+	err := base.toSnapshot(func(s *snapshot) error {
+		for _, ssk := range s.Sketches {
+			parentValues := di.extractParentValues(ssk.Values)
+			parentKey := hashGroupValues(parentValues)
+
+			ps, ok := sums[parentKey]
+			if !ok {
+				ps = &parentSum{values: append([]string{}, parentValues...)}
+				sums[parentKey] = ps
+			}
+			ps.sum += ssk.Sketch.Estimate()
+		}
+		return nil
+	})
+	if err != nil {
+		logger.Errorf("derived estimator: base toSnapshot failed: %s", err)
+	}
+
+	// 2. Add reject sketch estimates for rejected child groups.
+	di.rejectMu.Lock()
+	for bucketIdx, sketches := range di.rejectSketches {
+		values := di.rejectValues[bucketIdx]
+		for parentKey, sk := range sketches {
+			estimate := sk.Estimate()
+			if estimate == 0 {
+				continue
+			}
+			ps, ok := sums[parentKey]
+			if !ok {
+				ps = &parentSum{values: append([]string{}, values[parentKey]...)}
+				sums[parentKey] = ps
+			}
+			ps.sum += estimate
+		}
+	}
+
+	// 3. Reset reject sketches — estimates have been consumed.
+	for i := range di.rejectSketches {
+		di.rejectSketches[i] = nil
+		di.rejectValues[i] = nil
+	}
+	di.rejectMu.Unlock()
+
+	// 4. Emit metrics.
+	e.emitDerivedCardinality(w, sums)
+}
+
+// emitDerivedCardinality writes cardinality_estimate metrics from the
+// accumulated parent group sums, respecting the minCardinality filter.
+func (e *estimator) emitDerivedCardinality(w io.Writer, sums map[uint64]*parentSum) {
+	tmpBufP := getFormatBuf()
+	tmpBuf := *tmpBufP
+	defer func() {
+		*tmpBufP = tmpBuf
+		putFormatBuf(tmpBufP)
+	}()
+
+	eb0 := e.buckets[0]
+	metricPrefixB := appendCardinalityEstimateMetricPrefix(make([]byte, 0, 128), eb0.labels, eb0.interval, eb0.filter)
+	metricPrefix := bytesutil.ToUnsafeString(metricPrefixB)
+
+	if len(e.groupBy) == 0 {
+		// Global estimate: sum all parent groups into one value.
+		var total uint64
+		for _, ps := range sums {
+			total += ps.sum
+		}
+		if total < uint64(*cardinalityMetricsMinCardinality) {
+			return
+		}
+		tmpBuf = tmpBuf[:0]
+		tmpBuf = appendCardinalityEstimateGlobalMetric(tmpBuf, metricPrefix)
+		tmpBuf = strconv.AppendUint(tmpBuf, total, 10)
+		tmpBuf = append(tmpBuf, "\n"...)
+		_, _ = w.Write(tmpBuf)
+		return
+	}
+
+	// Grouped estimates.
+	groupByKeysLabelB := appendGroupByKeysLabel(make([]byte, 0, 128), `group_by_keys`, e.groupBy)
+	groupByKeysLabel := bytesutil.ToUnsafeString(groupByKeysLabelB)
+
+	for _, ps := range sums {
+		if ps.sum < uint64(*cardinalityMetricsMinCardinality) {
+			continue
+		}
+		tmpBuf = tmpBuf[:0]
+		tmpBuf = appendCardinalityEstimateGroupMetrics(tmpBuf, metricPrefix, groupByKeysLabel, e.groupBy, ps.values)
+		tmpBuf = strconv.AppendUint(tmpBuf, ps.sum, 10)
+		tmpBuf = append(tmpBuf, "\n"...)
+		if _, err := w.Write(tmpBuf); err != nil {
+			logger.Errorf("derived estimator: write failed: %s", err)
+			return
+		}
+	}
+}

--- a/app/vmestimator/derived_estimator_test.go
+++ b/app/vmestimator/derived_estimator_test.go
@@ -1,0 +1,503 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser"
+)
+
+func TestDerivedEstimatorNoRejects(t *testing.T) {
+	baseCfg := EstimatorConfig{
+		Interval:     time.Minute * 5,
+		GroupBy:      []string{"__name__", "job", "region"},
+		Buckets:      4,
+		HLLPrecision: 14,
+		GroupLimit:   100000,
+	}
+	derivedCfg := EstimatorConfig{
+		Interval:     time.Minute * 5,
+		GroupBy:      []string{"__name__"},
+		Buckets:      4,
+		HLLPrecision: 14,
+		GroupLimit:   100000,
+	}
+	independentCfg := EstimatorConfig{
+		Interval:     time.Minute * 5,
+		GroupBy:      []string{"__name__"},
+		Buckets:      4,
+		HLLPrecision: 14,
+		GroupLimit:   100000,
+	}
+
+	base, err := newEstimator(baseCfg)
+	if err != nil {
+		t.Fatalf("newEstimator base: %v", err)
+	}
+	defer base.stop()
+
+	derived, err := newEstimator(derivedCfg)
+	if err != nil {
+		t.Fatalf("newEstimator derived: %v", err)
+	}
+	defer derived.stop()
+
+	independent, err := newEstimator(independentCfg)
+	if err != nil {
+		t.Fatalf("newEstimator independent: %v", err)
+	}
+	defer independent.stop()
+
+	di, err := newDerivedInfo(base, derived, baseCfg)
+	if err != nil {
+		t.Fatalf("newDerivedInfo: %v", err)
+	}
+	derived.derived = di
+	base.baseFor = append(base.baseFor, derived)
+	for _, b := range base.buckets {
+		b.baseFor = base.baseFor
+	}
+
+	metricNames := []string{"http_requests_total", "grpc_duration_seconds", "go_goroutines"}
+	jobs := []string{"api", "worker", "scheduler"}
+	regions := []string{"us-east-1", "us-west-2", "eu-west-1"}
+
+	var tss []protoparser.TimeSerie
+	for _, name := range metricNames {
+		for _, job := range jobs {
+			for _, region := range regions {
+				for i := 0; i < 50; i++ {
+					tss = append(tss, protoparser.TimeSerie{
+						Labels: []protoparser.Label{
+							{Name: "__name__", Value: name},
+							{Name: "job", Value: job},
+							{Name: "region", Value: region},
+							{Name: "instance", Value: fmt.Sprintf("host-%d", i)},
+						},
+						Fingerprint: hash([]byte(fmt.Sprintf("%s/%s/%s/%d", name, job, region, i))),
+					})
+				}
+			}
+		}
+	}
+
+	base.insertMany(tss)
+	independent.insertMany(tss)
+
+	baseBuf := bytes.NewBuffer(nil)
+	derived.writeMetrics(baseBuf)
+	derivedOut := baseBuf.String()
+
+	indepBuf := bytes.NewBuffer(nil)
+	independent.writeMetrics(indepBuf)
+	indepOut := indepBuf.String()
+
+	for _, name := range metricNames {
+		derivedRe := regexp.MustCompile(fmt.Sprintf(`by__name__="%s"\}\s*(\d+)`, regexp.QuoteMeta(name)))
+		indepRe := regexp.MustCompile(fmt.Sprintf(`by__name__="%s"\}\s*(\d+)`, regexp.QuoteMeta(name)))
+
+		derivedMatch := derivedRe.FindStringSubmatch(derivedOut)
+		indepMatch := indepRe.FindStringSubmatch(indepOut)
+
+		if derivedMatch == nil {
+			t.Fatalf("derived output missing %s\noutput:\n%s", name, derivedOut)
+		}
+		if indepMatch == nil {
+			t.Fatalf("independent output missing %s\noutput:\n%s", name, indepOut)
+		}
+
+		derivedEst, _ := strconv.ParseUint(derivedMatch[1], 10, 64)
+		indepEst, _ := strconv.ParseUint(indepMatch[1], 10, 64)
+
+		if derivedEst != indepEst {
+			t.Errorf("estimate mismatch for %s: derived=%d independent=%d", name, derivedEst, indepEst)
+		}
+	}
+}
+
+func TestDerivedEstimatorWithRejects(t *testing.T) {
+	baseCfg := EstimatorConfig{
+		Interval:     time.Minute * 5,
+		GroupBy:      []string{"__name__", "job"},
+		Buckets:      4,
+		HLLPrecision: 14,
+		GroupLimit:   3,
+	}
+	derivedCfg := EstimatorConfig{
+		Interval:     time.Minute * 5,
+		GroupBy:      []string{"__name__"},
+		Buckets:      4,
+		HLLPrecision: 14,
+		GroupLimit:   100000,
+	}
+	independentCfg := EstimatorConfig{
+		Interval:     time.Minute * 5,
+		GroupBy:      []string{"__name__"},
+		Buckets:      4,
+		HLLPrecision: 14,
+		GroupLimit:   100000,
+	}
+
+	base, err := newEstimator(baseCfg)
+	if err != nil {
+		t.Fatalf("newEstimator base: %v", err)
+	}
+	defer base.stop()
+
+	derived, err := newEstimator(derivedCfg)
+	if err != nil {
+		t.Fatalf("newEstimator derived: %v", err)
+	}
+	defer derived.stop()
+
+	independent, err := newEstimator(independentCfg)
+	if err != nil {
+		t.Fatalf("newEstimator independent: %v", err)
+	}
+	defer independent.stop()
+
+	di, err := newDerivedInfo(base, derived, baseCfg)
+	if err != nil {
+		t.Fatalf("newDerivedInfo: %v", err)
+	}
+	derived.derived = di
+	base.baseFor = append(base.baseFor, derived)
+	for _, b := range base.buckets {
+		b.baseFor = base.baseFor
+	}
+
+	metricNames := []string{"metric_a", "metric_b"}
+	jobs := []string{"job1", "job2", "job3", "job4", "job5"}
+
+	var tss []protoparser.TimeSerie
+	for _, name := range metricNames {
+		for _, job := range jobs {
+			for i := 0; i < 100; i++ {
+				tss = append(tss, protoparser.TimeSerie{
+					Labels: []protoparser.Label{
+						{Name: "__name__", Value: name},
+						{Name: "job", Value: job},
+						{Name: "instance", Value: fmt.Sprintf("host-%d", i)},
+					},
+					Fingerprint: hash([]byte(fmt.Sprintf("%s/%s/%d", name, job, i))),
+				})
+			}
+		}
+	}
+
+	base.insertMany(tss)
+	independent.insertMany(tss)
+
+	baseBuf := bytes.NewBuffer(nil)
+	derived.writeMetrics(baseBuf)
+	derivedOut := baseBuf.String()
+
+	indepBuf := bytes.NewBuffer(nil)
+	independent.writeMetrics(indepBuf)
+	indepOut := indepBuf.String()
+
+	for _, name := range metricNames {
+		derivedRe := regexp.MustCompile(fmt.Sprintf(`by__name__="%s"\}\s*(\d+)`, regexp.QuoteMeta(name)))
+		indepRe := regexp.MustCompile(fmt.Sprintf(`by__name__="%s"\}\s*(\d+)`, regexp.QuoteMeta(name)))
+
+		derivedMatch := derivedRe.FindStringSubmatch(derivedOut)
+		indepMatch := indepRe.FindStringSubmatch(indepOut)
+
+		if derivedMatch == nil {
+			t.Fatalf("derived output missing %s\noutput:\n%s", name, derivedOut)
+		}
+		if indepMatch == nil {
+			t.Fatalf("independent output missing %s\noutput:\n%s", name, indepOut)
+		}
+
+		derivedEst, _ := strconv.ParseUint(derivedMatch[1], 10, 64)
+		indepEst, _ := strconv.ParseUint(indepMatch[1], 10, 64)
+
+		t.Logf("estimate for %s: derived=%d independent=%d", name, derivedEst, indepEst)
+
+		if derivedEst < indepEst {
+			t.Errorf("derived estimate for %s (%d) should not be less than independent (%d) — rejected fingerprints not captured",
+				name, derivedEst, indepEst)
+		}
+	}
+}
+
+func TestDerivedEstimatorGlobal(t *testing.T) {
+	baseCfg := EstimatorConfig{
+		Interval:     time.Minute * 5,
+		GroupBy:      []string{"__name__", "job"},
+		Buckets:      4,
+		HLLPrecision: 14,
+		GroupLimit:   100000,
+	}
+	derivedCfg := EstimatorConfig{
+		Interval:     time.Minute * 5,
+		GroupBy:      nil,
+		Buckets:      4,
+		HLLPrecision: 14,
+		GroupLimit:   100000,
+	}
+	independentCfg := EstimatorConfig{
+		Interval:     time.Minute * 5,
+		GroupBy:      nil,
+		Buckets:      4,
+		HLLPrecision: 14,
+		GroupLimit:   100000,
+	}
+
+	base, err := newEstimator(baseCfg)
+	if err != nil {
+		t.Fatalf("newEstimator base: %v", err)
+	}
+	defer base.stop()
+
+	derived, err := newEstimator(derivedCfg)
+	if err != nil {
+		t.Fatalf("newEstimator derived: %v", err)
+	}
+	defer derived.stop()
+
+	independent, err := newEstimator(independentCfg)
+	if err != nil {
+		t.Fatalf("newEstimator independent: %v", err)
+	}
+	defer independent.stop()
+
+	di, err := newDerivedInfo(base, derived, baseCfg)
+	if err != nil {
+		t.Fatalf("newDerivedInfo: %v", err)
+	}
+	derived.derived = di
+	base.baseFor = append(base.baseFor, derived)
+	for _, b := range base.buckets {
+		b.baseFor = base.baseFor
+	}
+
+	var tss []protoparser.TimeSerie
+	for _, name := range []string{"metric_a", "metric_b", "metric_c"} {
+		for _, job := range []string{"job1", "job2"} {
+			for i := 0; i < 100; i++ {
+				tss = append(tss, protoparser.TimeSerie{
+					Labels: []protoparser.Label{
+						{Name: "__name__", Value: name},
+						{Name: "job", Value: job},
+						{Name: "instance", Value: fmt.Sprintf("h%d", i)},
+					},
+					Fingerprint: hash([]byte(fmt.Sprintf("%s/%s/%d", name, job, i))),
+				})
+			}
+		}
+	}
+
+	base.insertMany(tss)
+	independent.insertMany(tss)
+
+	baseBuf := bytes.NewBuffer(nil)
+	derived.writeMetrics(baseBuf)
+	derivedOut := baseBuf.String()
+
+	indepBuf := bytes.NewBuffer(nil)
+	independent.writeMetrics(indepBuf)
+	indepOut := indepBuf.String()
+
+	derivedRe := regexp.MustCompile(`group_by_keys="__global__"\}\s*(\d+)`)
+	indepRe := regexp.MustCompile(`group_by_keys="__global__"\}\s*(\d+)`)
+
+	derivedMatch := derivedRe.FindStringSubmatch(derivedOut)
+	indepMatch := indepRe.FindStringSubmatch(indepOut)
+
+	if derivedMatch == nil {
+		t.Fatalf("derived output missing global estimate\noutput:\n%s", derivedOut)
+	}
+	if indepMatch == nil {
+		t.Fatalf("independent output missing global estimate\noutput:\n%s", indepOut)
+	}
+
+	derivedEst, _ := strconv.ParseUint(derivedMatch[1], 10, 64)
+	indepEst, _ := strconv.ParseUint(indepMatch[1], 10, 64)
+
+	t.Logf("global estimate: derived=%d independent=%d", derivedEst, indepEst)
+
+	if derivedEst != indepEst {
+		t.Errorf("global estimate mismatch: derived=%d independent=%d", derivedEst, indepEst)
+	}
+}
+
+func TestBuildParentToBase(t *testing.T) {
+	tests := []struct {
+		name        string
+		parentGroup []string
+		baseGroup   []string
+		want        []int
+		wantErr     bool
+	}{
+		{
+			name:        "subset",
+			parentGroup: []string{"__name__"},
+			baseGroup:   []string{"__name__", "job", "region"},
+			want:        []int{0},
+		},
+		{
+			name:        "two keys",
+			parentGroup: []string{"__name__", "region"},
+			baseGroup:   []string{"__name__", "job", "region"},
+			want:        []int{0, 2},
+		},
+		{
+			name:        "all keys",
+			parentGroup: []string{"__name__", "job", "region"},
+			baseGroup:   []string{"__name__", "job", "region"},
+			want:        []int{0, 1, 2},
+		},
+		{
+			name:        "empty parent (global)",
+			parentGroup: nil,
+			baseGroup:   []string{"__name__", "job"},
+			want:        nil,
+		},
+		{
+			name:        "not a subset",
+			parentGroup: []string{"__name__", "missing_key"},
+			baseGroup:   []string{"__name__", "job"},
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildParentToBase(tc.parentGroup, tc.baseGroup)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestDerivedEstimatorConfigValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "valid derivation",
+			yaml: `streams:
+  - interval: 5m
+    group_by: [__name__, job]
+    hll_precision: 14
+  - interval: 5m
+    group_by: [__name__]
+    hll_precision: 14
+    derive_from: 0
+`,
+		},
+		{
+			name: "interval mismatch",
+			yaml: `streams:
+  - interval: 5m
+    group_by: [__name__, job]
+    hll_precision: 14
+  - interval: 10m
+    group_by: [__name__]
+    hll_precision: 14
+    derive_from: 0
+`,
+			wantErr: "same interval",
+		},
+		{
+			name: "filter mismatch",
+			yaml: `streams:
+  - interval: 5m
+    filter: '{__name__=~"foo.*"}'
+    group_by: [__name__, job]
+    hll_precision: 14
+  - interval: 5m
+    group_by: [__name__]
+    hll_precision: 14
+    derive_from: 0
+`,
+			wantErr: "same filter",
+		},
+		{
+			name: "group_by not subset",
+			yaml: `streams:
+  - interval: 5m
+    group_by: [__name__]
+    hll_precision: 14
+  - interval: 5m
+    group_by: [job]
+    hll_precision: 14
+    derive_from: 0
+`,
+			wantErr: "not found in base stream",
+		},
+		{
+			name: "derive from global (no group_by)",
+			yaml: `streams:
+  - interval: 5m
+    hll_precision: 14
+  - interval: 5m
+    group_by: [__name__]
+    hll_precision: 14
+    derive_from: 0
+`,
+			wantErr: "no group_by",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := tmpDir + "/config.yaml"
+			if err := writeFile(path, tc.yaml); err != nil {
+				t.Fatalf("writeFile: %v", err)
+			}
+			es, err := loadConfig(path)
+			if tc.wantErr != "" {
+				if err == nil {
+					if es != nil {
+						for _, e := range es {
+							e.stop()
+						}
+					}
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, e := range es {
+				e.stop()
+			}
+		})
+	}
+}
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -34,6 +34,17 @@ type estimator struct {
 	insertTotal *metrics.Counter
 
 	stopCh chan struct{}
+
+	// derived is non-nil when this estimator derives estimates from a base
+	// estimator instead of maintaining its own HLL sketches. When set,
+	// writeMetrics calls writeDerivedMetrics instead of the normal path.
+	derived *derivedInfo
+
+	// baseFor is the list of estimators that derive from this one. When a
+	// group is rejected due to group_limit, the base estimator calls
+	// insertRejected on each derived estimator so the fingerprints are not
+	// lost.
+	baseFor []*estimator
 }
 
 func newEstimator(cfg EstimatorConfig) (*estimator, error) {
@@ -366,6 +377,11 @@ func (e *estimator) toSnapshot(cb func(s *snapshot) error) error {
 }
 
 func (e *estimator) writeMetrics(w io.Writer) {
+	if e.derived != nil {
+		e.writeDerivedMetrics(w)
+		return
+	}
+
 	var dropped uint64
 	if err := e.toSnapshot(func(s *snapshot) error {
 		d, err := s.writeCardinalityEstimates(w)
@@ -439,6 +455,10 @@ type estimatorBucket struct {
 	groupSize  *groupSize
 	groups     map[uint64]groupSketch
 	prevGroups map[uint64]groupSketch
+
+	// baseFor is the list of derived estimators to notify when a group is
+	// rejected due to group_limit.
+	baseFor []*estimator
 }
 
 func (eb *estimatorBucket) reset() {
@@ -489,6 +509,9 @@ func (eb *estimatorBucket) insert(fp uint64, groupValuesKey uint64, groupValues 
 			values = prevGSK.values
 		} else {
 			if !eb.groupSize.allowInsertLocked(eb.idx, groupValuesKey) {
+				for _, de := range eb.baseFor {
+					de.derived.insertRejected(eb.idx, groupValues, fp)
+				}
 				eb.mu.Unlock()
 				return
 			}


### PR DESCRIPTION
## Summary

Allow a stream to derive its cardinality estimates from a more granular "base" stream instead of maintaining its own HLL sketches, reducing CPU cost per scrape.

## Motivation

When multiple streams group by overlapping label sets (e.g. `[__name__]` and `[__name__, job, region]`), every scraped series is inserted into N independent HLL estimators. For the less-granular streams, the estimates can be derived by summing the more-granular stream's per-group estimates — no separate HLL insertions needed.

This is safe because groups are **disjoint by construction** (each series maps to exactly one group), so `sum(Estimate(group_A), Estimate(group_B), ...) = Estimate(merged)` in expectation. No HLL merge is required — just arithmetic at snapshot time.

## Group limit handling

When the base estimator rejects a group due to `group_limit`, the fingerprint is inserted into a **parent-keyed reject HLL** on the derived estimator. At snapshot time, the derived estimate sums both the accepted group estimates and the reject HLL estimates, so accuracy is preserved even when groups are rejected.

## Config

```yaml
streams:
  - interval: 5m
    hll_precision: 10
    group_limit: 987654321
  - group_by: [__name__]
    interval: 5m
    hll_precision: 10
    group_limit: 987654321
    derive_from: 2          # derive from stream index 2
  - group_by: [__name__, task_name, region]
    interval: 5m
    hll_precision: 10
    group_limit: 987654321
```

Stream 1 (index 1) no longer maintains its own HLL sketches — it sums stream 2's per-group estimates at snapshot time.

## Constraints

- Derived `group_by` must be a subset of the base `group_by`
- `interval`, `filter`, and `hll_precision` must match between derived and base
- `__label__` is not supported in derived or base streams
- Derived stream does not maintain its own buckets/sketches — it only holds reject HLLs for overflow fingerprints

## Changes

- `config.go`: Added `DeriveFrom *int` field to `EstimatorConfig`, validation in `loadConfig`
- `estimator.go`: Added `derived`/`baseFor` fields, reject hook in `insert`, `writeDerivedMetrics` branch in `writeMetrics`
- `derived_estimator.go` (new): `derivedInfo` struct, `insertRejected`, `writeDerivedMetrics`, `buildParentToBase`
- `derived_estimator_test.go` (new): Tests for no-rejects, with-rejects, global derivation, config validation, index mapping

## Test results

- **No rejects**: derived estimate exactly matches independent estimator
- **With rejects** (group_limit=3, 10 groups): derived=500, independent=500 — reject sketches correctly capture lost fingerprints
- **Global derivation**: derived=600, independent=600

## Status

Experimental — seeking feedback on the design and API before finalizing.