### PR TITLE
app/vmestimator: add time series deduplicator

### DIFF
--- a/app/vmestimator/deduplicator.go
+++ b/app/vmestimator/deduplicator.go
@@ -84,8 +84,8 @@ func newDeduplicator(maxSize int, interval time.Duration) *deduplicator {
 	}
 
 	e, err := newEstimator(EstimatorConfig{
-		Interval: interval,
-		HLLSparse: new(false),
+		Interval:     interval,
+		HLLSparse:    new(false),
 		HLLPrecision: 12,
 	})
 	if err != nil {

--- a/app/vmestimator/deduplicator.go
+++ b/app/vmestimator/deduplicator.go
@@ -1,0 +1,263 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/memory"
+	"github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser"
+	"github.com/axiomhq/hyperloglog"
+)
+
+var (
+	deduplicationInterval    = flag.Duration("deduplication.interval", 0, "Time window for deduplication. When set, time series already seen within the window are dropped before being forwarded to estimators. Disabled when set to 0.")
+	deduplicatorMaxSizeBytes = flagutil.NewBytes("deduplication.maxSizeBytes", 0, "Memory budget for deduplication bloom filters, e.g. 100MB. "+
+		"Controls how many unique time series can be tracked before the deduplicator gradually switches to pass-through mode. "+
+		"Defaults to 5 percent of allowed memory. When both -deduplication.maxSizeBytes and -deduplication.maxSize are set, the stricter limit is used.")
+	deduplicatorMaxSize = flag.Int("deduplication.maxSize", 0, "Maximum number of unique time series the deduplicator tracks. "+
+		"When the true cardinality exceeds this limit, the deduplicator gradually passes through the excess series instead of deduplicating them. "+
+		"Defaults to a value derived from 5 percent of allowed memory. When both -deduplication.maxSizeBytes and -deduplication.maxSize are set, the stricter limit is used.")
+)
+
+// resolveDeduplicatorMaxSize returns the maximum number of unique time series
+// the deduplicator will track, derived from the configured flags.
+func resolveDeduplicatorMaxSize() int {
+	fromBytes := 0
+	if deduplicatorMaxSizeBytes.N > 0 {
+		fromBytes = convertDeduplicatorMaxSizeBytesToItems(int(deduplicatorMaxSizeBytes.N))
+	}
+	fromCount := *deduplicatorMaxSize
+
+	switch {
+	case fromBytes > 0 && fromCount > 0:
+		return min(fromBytes, fromCount)
+	case fromBytes > 0:
+		return fromBytes
+	case fromCount > 0:
+		return fromCount
+	default:
+		// Default: 5% of allowed memory.
+		allowed := int(float64(memory.Allowed()) * 0.05)
+		return convertDeduplicatorMaxSizeBytesToItems(allowed)
+	}
+}
+
+type deduplicator struct {
+	maxSize       int
+	interval      time.Duration
+	bucketMaxSize int
+
+	// 10 independent bloom filter buckets.
+	// Each series maps to bucket fingerprint%10.
+	// Rotation clears one bucket per interval/10 on a fixed-grid schedule,
+	// smoothing CPU spikes across time.
+	bfs [10]atomic.Pointer[deduplicatorBloomFilter]
+
+	// HLL sketches for estimating the true unique-series count.
+	skMu   sync.Mutex
+	currSk *hyperloglog.Sketch
+	prevSk *hyperloglog.Sketch
+
+	// Gradual pass-through ratio stored per-1000.
+	// 0 = deduplicate all; 1000 = pass everything through.
+	// When unique > maxSize, ratio = (unique - maxSize) * 1000 / unique.
+	passthroughPer1000 atomic.Int64
+
+	stopCh chan struct{}
+}
+
+func newDeduplicator(maxSize int, interval time.Duration) *deduplicator {
+	if maxSize <= 1000 {
+		panic("BUG: maxSize must be greater than 1000")
+	}
+	if interval <= time.Second*30 {
+		panic("BUG: interval must be greater than 30s")
+	}
+
+	d := &deduplicator{
+		maxSize:       maxSize,
+		interval:      interval,
+		bucketMaxSize: maxSize / 10,
+		currSk:        newDeduplicatorSketch(),
+		prevSk:        newDeduplicatorSketch(),
+		stopCh:        make(chan struct{}),
+	}
+
+	for i := range d.bfs {
+		d.bfs[i].Store(newDeduplicatorBloomFilter(d.bucketMaxSize))
+	}
+
+	go d.runRotation()
+	return d
+}
+
+// filter filters out time series already seen within the deduplication interval.
+// src is the incoming batch; dst is the destination slice (may be nil or pre-allocated).
+// The returned slice contains only time series that should be forwarded to estimators.
+func (d *deduplicator) filter(src, dst []protoparser.TimeSerie) []protoparser.TimeSerie {
+	// Update HLL with every incoming series before filtering, so cardinality
+	// estimates reflect true inbound volume regardless of deduplication decisions.
+	d.skMu.Lock()
+	for i := range src {
+		d.currSk.InsertHash(src[i].Fingerprint)
+	}
+	d.skMu.Unlock()
+
+	passthrough := d.passthroughPer1000.Load()
+
+	for i := range src {
+		ts := src[i]
+		h := ts.Fingerprint
+
+		// Overflow pass-through: deterministic by hash so the same series
+		// always lands on the same side of the split.
+		if passthrough > 0 && int64(h%1000) < passthrough {
+			dst = append(dst, ts)
+			continue
+		}
+
+		bf := d.bfs[h%10].Load()
+		if !bf.contains(h) {
+			bf.add(h)
+			dst = append(dst, ts)
+		}
+	}
+	return dst
+}
+
+func (d *deduplicator) Stop() {
+	close(d.stopCh)
+}
+
+func (d *deduplicator) runRotation() {
+	bucketDur := d.interval / 10
+
+	for {
+		now := time.Now()
+		nextBoundary := now.Truncate(bucketDur).Add(bucketDur)
+		t := time.NewTimer(nextBoundary.Sub(now))
+		select {
+		case <-t.C:
+		case <-d.stopCh:
+			t.Stop()
+			return
+		}
+
+		idx := (nextBoundary.UnixNano() / int64(bucketDur)) % 10
+		d.bfs[idx].Store(newDeduplicatorBloomFilter(d.bucketMaxSize))
+
+		// Recalculate pass-through ratio after each bucket rotation.
+		d.skMu.Lock()
+		resSk := newDeduplicatorSketch()
+		_ = resSk.Merge(d.currSk)
+		_ = resSk.Merge(d.prevSk)
+		d.skMu.Unlock()
+		unique := resSk.Estimate()
+
+		var ratio int64
+		if unique > uint64(d.maxSize) {
+			ratio = int64((unique - uint64(d.maxSize)) * 1000 / unique)
+		}
+		d.passthroughPer1000.Store(ratio)
+
+		// Rotate HLL sketches once per full interval (every 10 bucket rotations).
+		if idx == 0 {
+			newSk := newDeduplicatorSketch()
+			d.skMu.Lock()
+			d.prevSk = d.currSk
+			d.currSk = newSk
+			d.skMu.Unlock()
+			logger.Infof("deduplicator: unique series estimate=%d maxSize=%d passthrough=%d/1000", unique, d.maxSize, ratio)
+		}
+	}
+}
+
+const hashesCount = 4
+const bitsPerItem = 16
+
+type deduplicatorBloomFilter struct {
+	bits []uint64
+}
+
+func newDeduplicatorBloomFilter(maxItems int) *deduplicatorBloomFilter {
+	return &deduplicatorBloomFilter{
+		bits: newBits(uint64(maxItems)),
+	}
+}
+
+// contains returns true if h was previously added to this filter.
+func (f *deduplicatorBloomFilter) contains(h uint64) bool {
+	bits := f.bits
+	maxBits := uint64(len(bits)) * 64
+	h1 := h & 0xFFFFFFFF
+	h2 := h >> 32
+	for i := uint64(0); i < hashesCount; i++ {
+		idx := (h1 + i*h2) % maxBits
+		word := idx / 64
+		bit := idx % 64
+		mask := uint64(1) << bit
+		if atomic.LoadUint64(&bits[word])&mask == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// add adds h to the filter. Returns true if the item appears to be new
+// (at least one bit needed to be set).
+func (f *deduplicatorBloomFilter) add(h uint64) bool {
+	bits := f.bits
+	maxBits := uint64(len(bits)) * 64
+
+	// Kirsch-Mitzenmacher double hashing: derive k indices from two halves of h
+	// using h_i = (h1 + i*h2) % maxBits, avoiding k separate hash computations.
+	h1 := h & 0xFFFFFFFF
+	h2 := h >> 32
+
+	isNew := false
+	for i := uint64(0); i < hashesCount; i++ {
+		idx := (h1 + i*h2) % maxBits
+		word := idx / 64
+		bit := idx % 64
+		mask := uint64(1) << bit
+		w := atomic.LoadUint64(&bits[word])
+		for w&mask == 0 {
+			// The w|mask != w most of the time, so there is no need in using atomic.LoadUint64
+			// in front of atomic.CompareAndSwapUint64 in order to try avoiding slow inter-CPU synchronization.
+			if atomic.CompareAndSwapUint64(&bits[word], w, w|mask) {
+				isNew = true
+				break
+			}
+			w = atomic.LoadUint64(&bits[word])
+		}
+	}
+	return isNew
+}
+
+func newBits(maxItems uint64) []uint64 {
+	bitsCount := maxItems * bitsPerItem
+	return make([]uint64, (bitsCount+63)/64)
+}
+
+func newDeduplicatorSketch() *hyperloglog.Sketch {
+	sk, err := hyperloglog.NewSketch(12, false)
+	if err != nil {
+		panic(fmt.Sprintf("BUG: hyperloglog: new sketch: %s", err))
+	}
+	return sk
+}
+
+func convertDeduplicatorMaxSizeBytesToItems(bytes int) int {
+	// Subtract memory used by the two HLL sketches (2 * 2^12 bytes).
+	skBytes := 2 * (1 << 12)
+	bytes -= skBytes
+	if bytes <= 0 {
+		return 0
+	}
+	return bytes * 8 / bitsPerItem
+}

--- a/app/vmestimator/deduplicator.go
+++ b/app/vmestimator/deduplicator.go
@@ -136,6 +136,7 @@ func (d *deduplicator) Stop() {
 
 func (d *deduplicator) runRotation() {
 	bucketDur := d.interval / 10
+	var prevRatio int64
 
 	for {
 		now := time.Now()
@@ -172,6 +173,10 @@ func (d *deduplicator) runRotation() {
 			d.prevSk = d.currSk
 			d.currSk = newSk
 			d.skMu.Unlock()
+		}
+
+		if ratio != prevRatio {
+			prevRatio = ratio
 			logger.Infof("deduplicator: unique series estimate=%d maxSize=%d passthrough=%d/1000", unique, d.maxSize, ratio)
 		}
 	}

--- a/app/vmestimator/deduplicator.go
+++ b/app/vmestimator/deduplicator.go
@@ -18,9 +18,10 @@ var (
 	deduplicationInterval    = flag.Duration("deduplication.interval", 0, "Time window for deduplication. When set, time series already seen within the window are dropped before being forwarded to estimators. Disabled when set to 0.")
 	deduplicatorMaxSizeBytes = flagutil.NewBytes("deduplication.maxSizeBytes", 0, "Memory budget for deduplication bloom filters, e.g. 100MB. "+
 		"Controls how many unique time series can be tracked before the deduplicator gradually switches to pass-through mode. "+
+		"Pass-through starts at 80%% of the limit to keep bloom filters well below saturation. "+
 		"Defaults to 5 percent of allowed memory. When both -deduplication.maxSizeBytes and -deduplication.maxSize are set, the stricter limit is used.")
 	deduplicatorMaxSize = flag.Int("deduplication.maxSize", 0, "Maximum number of unique time series the deduplicator tracks. "+
-		"When the true cardinality exceeds this limit, the deduplicator gradually passes through the excess series instead of deduplicating them. "+
+		"Pass-through begins at 80%% of this limit so bloom filters never saturate and start producing false positives. "+
 		"Defaults to a value derived from 5 percent of allowed memory. When both -deduplication.maxSizeBytes and -deduplication.maxSize are set, the stricter limit is used.")
 )
 
@@ -160,9 +161,13 @@ func (d *deduplicator) runRotation() {
 		d.skMu.Unlock()
 		unique := resSk.Estimate()
 
+		// Start pass-through at 80% of maxSize so the bloom filters never
+		// reach saturation: at full capacity false-positive rate spikes,
+		// which would silently drop legitimate new series.
+		passthroughThreshold := uint64(d.maxSize) * 4 / 5
 		var ratio int64
-		if unique > uint64(d.maxSize) {
-			ratio = int64((unique - uint64(d.maxSize)) * 1000 / unique)
+		if unique > passthroughThreshold {
+			ratio = int64((unique - passthroughThreshold) * 1000 / unique)
 		}
 		d.passthroughPer1000.Store(ratio)
 

--- a/app/vmestimator/deduplicator.go
+++ b/app/vmestimator/deduplicator.go
@@ -73,10 +73,10 @@ type deduplicator struct {
 }
 
 func newDeduplicator(maxSize int, interval time.Duration) *deduplicator {
-	if maxSize <= 1000 {
+	if maxSize <= 0 {
 		panic("BUG: maxSize must be greater than 1000")
 	}
-	if interval <= time.Second*30 {
+	if interval <= 0 {
 		panic("BUG: interval must be greater than 30s")
 	}
 

--- a/app/vmestimator/deduplicator.go
+++ b/app/vmestimator/deduplicator.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/memory"
 	"github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser"
-	"github.com/axiomhq/hyperloglog"
 )
 
 var (
@@ -59,10 +57,10 @@ type deduplicator struct {
 	// smoothing CPU spikes across time.
 	bfs [10]atomic.Pointer[deduplicatorBloomFilter]
 
-	// HLL sketches for estimating the true unique-series count.
-	skMu   sync.Mutex
-	currSk *hyperloglog.Sketch
-	prevSk *hyperloglog.Sketch
+	// e estimates the true unique-series count using an estimator in global
+	// mode (no group_by). Its sharded buckets avoid any global lock on the
+	// write path.
+	e *estimator
 
 	// Gradual pass-through ratio stored per-1000.
 	// 0 = deduplicate all; 1000 = pass everything through.
@@ -72,20 +70,33 @@ type deduplicator struct {
 	stopCh chan struct{}
 }
 
+const (
+	deduplicationMinMaxSize  = 9999
+	deduplicationMinInterval = time.Second * 30
+)
+
 func newDeduplicator(maxSize int, interval time.Duration) *deduplicator {
-	if maxSize <= 0 {
-		panic("BUG: maxSize must be greater than 1000")
+	if maxSize <= deduplicationMinMaxSize {
+		panic(fmt.Sprintf("BUG: maxSize must be greater than %d; got %d", deduplicationMinMaxSize, maxSize))
 	}
-	if interval <= 0 {
-		panic("BUG: interval must be greater than 30s")
+	if interval <= deduplicationMinInterval {
+		panic(fmt.Sprintf("BUG: interval must be greater than %v; got %v", deduplicationMinInterval, interval))
+	}
+
+	e, err := newEstimator(EstimatorConfig{
+		Interval: interval,
+		HLLSparse: new(false),
+		HLLPrecision: 12,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("BUG: cannot create deduplicator estimator: %s", err))
 	}
 
 	d := &deduplicator{
 		maxSize:       maxSize,
 		interval:      interval,
 		bucketMaxSize: maxSize / 10,
-		currSk:        newDeduplicatorSketch(),
-		prevSk:        newDeduplicatorSketch(),
+		e:             e,
 		stopCh:        make(chan struct{}),
 	}
 
@@ -101,13 +112,14 @@ func newDeduplicator(maxSize int, interval time.Duration) *deduplicator {
 // src is the incoming batch; dst is the destination slice (may be nil or pre-allocated).
 // The returned slice contains only time series that should be forwarded to estimators.
 func (d *deduplicator) filter(src, dst []protoparser.TimeSerie) []protoparser.TimeSerie {
-	// Update HLL with every incoming series before filtering, so cardinality
-	// estimates reflect true inbound volume regardless of deduplication decisions.
-	d.skMu.Lock()
-	for i := range src {
-		d.currSk.InsertHash(src[i].Fingerprint)
+	if len(src) == 0 {
+		return dst
 	}
-	d.skMu.Unlock()
+
+	// Update the estimator with every incoming series before filtering, so
+	// cardinality estimates reflect true inbound volume regardless of deduplication
+	// decisions.
+	d.e.insertMany(src)
 
 	passthrough := d.passthroughPer1000.Load()
 
@@ -133,6 +145,7 @@ func (d *deduplicator) filter(src, dst []protoparser.TimeSerie) []protoparser.Ti
 
 func (d *deduplicator) Stop() {
 	close(d.stopCh)
+	d.e.stop()
 }
 
 func (d *deduplicator) runRotation() {
@@ -154,12 +167,8 @@ func (d *deduplicator) runRotation() {
 		d.bfs[idx].Store(newDeduplicatorBloomFilter(d.bucketMaxSize))
 
 		// Recalculate pass-through ratio after each bucket rotation.
-		d.skMu.Lock()
-		resSk := newDeduplicatorSketch()
-		_ = resSk.Merge(d.currSk)
-		_ = resSk.Merge(d.prevSk)
-		d.skMu.Unlock()
-		unique := resSk.Estimate()
+		// The estimator handles its own sketch rotation; we just read the estimate.
+		unique := d.e.estimate()
 
 		// Start pass-through at 80% of maxSize so the bloom filters never
 		// reach saturation: at full capacity false-positive rate spikes,
@@ -170,15 +179,6 @@ func (d *deduplicator) runRotation() {
 			ratio = int64((unique - passthroughThreshold) * 1000 / unique)
 		}
 		d.passthroughPer1000.Store(ratio)
-
-		// Rotate HLL sketches once per full interval (every 10 bucket rotations).
-		if idx == 0 {
-			newSk := newDeduplicatorSketch()
-			d.skMu.Lock()
-			d.prevSk = d.currSk
-			d.currSk = newSk
-			d.skMu.Unlock()
-		}
 
 		if ratio != prevRatio {
 			prevRatio = ratio
@@ -254,20 +254,6 @@ func newBits(maxItems uint64) []uint64 {
 	return make([]uint64, (bitsCount+63)/64)
 }
 
-func newDeduplicatorSketch() *hyperloglog.Sketch {
-	sk, err := hyperloglog.NewSketch(12, false)
-	if err != nil {
-		panic(fmt.Sprintf("BUG: hyperloglog: new sketch: %s", err))
-	}
-	return sk
-}
-
 func convertDeduplicatorMaxSizeBytesToItems(bytes int) int {
-	// Subtract memory used by the two HLL sketches (2 * 2^12 bytes).
-	skBytes := 2 * (1 << 12)
-	bytes -= skBytes
-	if bytes <= 0 {
-		return 0
-	}
 	return bytes * 8 / bitsPerItem
 }

--- a/app/vmestimator/deduplicator.go
+++ b/app/vmestimator/deduplicator.go
@@ -16,10 +16,10 @@ var (
 	deduplicationInterval    = flag.Duration("deduplication.interval", 0, "Time window for deduplication. When set, time series already seen within the window are dropped before being forwarded to estimators. Disabled when set to 0.")
 	deduplicatorMaxSizeBytes = flagutil.NewBytes("deduplication.maxSizeBytes", 0, "Memory budget for deduplication bloom filters, e.g. 100MB. "+
 		"Controls how many unique time series can be tracked before the deduplicator gradually switches to pass-through mode. "+
-		"Pass-through starts at 80%% of the limit to keep bloom filters well below saturation. "+
+		"Pass-through starts at 80% of the limit to keep bloom filters well below saturation. "+
 		"Defaults to 5 percent of allowed memory. When both -deduplication.maxSizeBytes and -deduplication.maxSize are set, the stricter limit is used.")
 	deduplicatorMaxSize = flag.Int("deduplication.maxSize", 0, "Maximum number of unique time series the deduplicator tracks. "+
-		"Pass-through begins at 80%% of this limit so bloom filters never saturate and start producing false positives. "+
+		"Pass-through begins at 80% of this limit so bloom filters never saturate and start producing false positives. "+
 		"Defaults to a value derived from 5 percent of allowed memory. When both -deduplication.maxSizeBytes and -deduplication.maxSize are set, the stricter limit is used.")
 )
 

--- a/app/vmestimator/deduplicator_test.go
+++ b/app/vmestimator/deduplicator_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser"
+)
+
+func TestDeduplicatorBloomFilter(t *testing.T) {
+	bf := newDeduplicatorBloomFilter(10_000)
+
+	// Not added yet.
+	if bf.contains(1) {
+		t.Fatal("contains(1): expected false before any add")
+	}
+
+	// First add: item is new.
+	if !bf.add(1) {
+		t.Fatal("add(1): expected true (new item)")
+	}
+	if !bf.contains(1) {
+		t.Fatal("contains(1): expected true after add")
+	}
+
+	// Second add: already present.
+	if bf.add(1) {
+		t.Fatal("add(1): expected false (already present)")
+	}
+
+	// Unrelated hash is unaffected.
+	if bf.contains(2) {
+		t.Fatal("contains(2): expected false (never added)")
+	}
+
+	// Many items: first insertion is new, second is not.
+	for i := uint64(2); i <= 1000; i++ {
+		if !bf.add(i) {
+			t.Fatalf("add(%d): expected true on first insert", i)
+		}
+	}
+	for i := uint64(2); i <= 1000; i++ {
+		if bf.add(i) {
+			t.Fatalf("add(%d): expected false on second insert", i)
+		}
+	}
+}
+
+func TestDeduplicator_filter(t *testing.T) {
+	d := newDeduplicator(10_000, time.Hour)
+	defer d.Stop()
+
+	makeTSS := func(fps ...uint64) []protoparser.TimeSerie {
+		tss := make([]protoparser.TimeSerie, len(fps))
+		for i, fp := range fps {
+			tss[i] = protoparser.TimeSerie{Fingerprint: fp}
+		}
+		return tss
+	}
+
+	f := func(src, exp []protoparser.TimeSerie) {
+		t.Helper()
+		dst := d.filter(src, nil)
+		if !reflect.DeepEqual(dst, exp) {
+			t.Fatalf("filter: expected %v, got %v", exp, dst)
+		}
+	}
+
+	// fp 1,2,3 go to buckets 1,2,3 respectively (fp%10).
+	tss := makeTSS(1, 2, 3)
+
+	// First pass: all unique, all pass through.
+	f(tss, makeTSS(1, 2, 3))
+
+	// Second pass: all already seen, all filtered.
+	f(tss, nil)
+
+	// Mixed: known + new. Only the new one (fp=4) passes.
+	f(makeTSS(1, 4), makeTSS(4))
+
+	// Clear bucket 1 (holds fp=1). fp=1 passes through again; fp=2 still filtered.
+	d.bfs[1].Store(newDeduplicatorBloomFilter(d.bucketMaxSize))
+	f(makeTSS(1, 2), makeTSS(1))
+
+	// Clear all buckets: every series is new again.
+	for i := range d.bfs {
+		d.bfs[i].Store(newDeduplicatorBloomFilter(d.bucketMaxSize))
+	}
+	f(tss, makeTSS(1, 2, 3))
+}
+
+func TestDeduplicator_filterPassthrough(t *testing.T) {
+	d := newDeduplicator(10_000, time.Hour)
+	defer d.Stop()
+
+	makeTSS := func(fps ...uint64) []protoparser.TimeSerie {
+		tss := make([]protoparser.TimeSerie, len(fps))
+		for i, fp := range fps {
+			tss[i] = protoparser.TimeSerie{Fingerprint: fp}
+		}
+		return tss
+	}
+
+	f := func(src, exp []protoparser.TimeSerie) {
+		t.Helper()
+		dst := d.filter(src, nil)
+		if !reflect.DeepEqual(dst, exp) {
+			t.Fatalf("filter: expected %v, got %v", exp, dst)
+		}
+	}
+
+	// Build a batch that spans both sides of the 500 threshold.
+	// fp%1000: 1,101,201,301,401 < 500 (pass); 501,601,701,801,901 >= 500 (no pass).
+	tss := makeTSS(1, 101, 201, 301, 401, 501, 601, 701, 801, 901)
+
+	// Seed BF so all series are "already seen".
+	d.filter(tss, nil)
+	f(tss, nil)
+
+	// Full passthrough: all series pass regardless of BF state.
+	d.passthroughPer1000.Store(1000)
+	f(tss, tss)
+
+	// 50% passthrough: only series with fp%1000 < 500 pass through.
+	d.passthroughPer1000.Store(500)
+	exp := makeTSS(1, 101, 201, 301, 401)
+	f(tss, exp)
+
+	// Passthrough decision is deterministic: repeated calls yield the same result.
+	f(tss, exp)
+}

--- a/app/vmestimator/deduplicator_timing_test.go
+++ b/app/vmestimator/deduplicator_timing_test.go
@@ -15,7 +15,7 @@ func BenchmarkDeduplicator_filter(b *testing.B) {
 	const seriesCount = 10_000
 	tss := make([]protoparser.TimeSerie, seriesCount)
 	for i := range tss {
-		tss[i].Fingerprint = hash([]byte("foo"+strconv.Itoa(i)))
+		tss[i].Fingerprint = hash([]byte("foo" + strconv.Itoa(i)))
 	}
 
 	b.ResetTimer()

--- a/app/vmestimator/deduplicator_timing_test.go
+++ b/app/vmestimator/deduplicator_timing_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser"
+)
+
+func BenchmarkDeduplicator_filter(b *testing.B) {
+	d := newDeduplicator(100_000, time.Minute)
+	defer d.Stop()
+
+	const seriesCount = 10_000
+	tss := make([]protoparser.TimeSerie, seriesCount)
+	for i := range tss {
+		tss[i].Fingerprint = hash([]byte("foo"+strconv.Itoa(i)))
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		dst := d.filter(tss, tss[:0])
+		_ = dst
+	}
+}

--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -365,6 +365,18 @@ func (e *estimator) toSnapshot(cb func(s *snapshot) error) error {
 	return cb(s)
 }
 
+// estimate returns the current unique-series count by merging all bucket sketches.
+func (e *estimator) estimate() uint64 {
+	eb0 := e.buckets[0]
+	resSK := eb0.newSketch()
+	for _, eb := range e.buckets {
+		eb.mu.Lock()
+		eb.mergeSketches(eb.sketch, eb.prevSketch, resSK)
+		eb.mu.Unlock()
+	}
+	return resSK.Estimate()
+}
+
 func (e *estimator) writeMetrics(w io.Writer) {
 	var dropped uint64
 	if err := e.toSnapshot(func(s *snapshot) error {

--- a/app/vmestimator/main.go
+++ b/app/vmestimator/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -33,7 +32,6 @@ var (
 )
 
 func main() {
-	flag.CommandLine.SetOutput(os.Stdout)
 	envflag.Parse()
 	buildinfo.Init()
 	logger.Init()
@@ -53,6 +51,17 @@ func main() {
 
 	startWorkers()
 	defer stopWorkers()
+
+	var dedup *deduplicator
+	if *deduplicationInterval > 0 {
+		maxSize := resolveDeduplicatorMaxSize()
+		if maxSize <= 0 {
+			logger.Fatalf("deduplicator maxSize must be greater than 0; set -deduplication.maxSize or -deduplication.maxSizeBytes")
+		}
+		dedup = newDeduplicator(maxSize, *deduplicationInterval)
+		defer dedup.Stop()
+		logger.Infof("deduplicator enabled: interval=%s maxSize=%d", *deduplicationInterval, maxSize)
+	}
 
 	if *cardinalityMetricsExposeAt == `/metrics` {
 		metrics.RegisterMetricsWriter(func(w io.Writer) {
@@ -81,6 +90,9 @@ func main() {
 		case "/api/v1/write":
 			prometheusWriteRequests.Inc()
 			err := protoparser.Parse(r.Body, func(tss []protoparser.TimeSerie) {
+				if dedup != nil {
+					tss = dedup.filter(tss, tss[:0])
+				}
 				const chunkSize = 100
 				esLen := uint32(len(es))
 				wg := &sync.WaitGroup{}

--- a/app/vmestimator/main.go
+++ b/app/vmestimator/main.go
@@ -60,7 +60,8 @@ func main() {
 		}
 		dedup = newDeduplicator(maxSize, *deduplicationInterval)
 		defer dedup.Stop()
-		logger.Infof("deduplicator enabled: interval=%s maxSize=%d sizeBytes=%d", *deduplicationInterval, maxSize, maxSize*bitsPerItem/8)
+		passthroughThreshold := maxSize * 4 / 5
+		logger.Infof("deduplicator enabled: interval=%s maxSize=%d passthroughThreshold=%d sizeBytes=%d", *deduplicationInterval, maxSize, passthroughThreshold, maxSize*bitsPerItem/8)
 	}
 
 	if *cardinalityMetricsExposeAt == `/metrics` {
@@ -92,6 +93,9 @@ func main() {
 			err := protoparser.Parse(r.Body, func(tss []protoparser.TimeSerie) {
 				if dedup != nil {
 					tss = dedup.filter(tss, tss[:0])
+					if len(tss) == 0 {
+						return
+					}
 				}
 				const chunkSize = 100
 				esLen := uint32(len(es))

--- a/app/vmestimator/main.go
+++ b/app/vmestimator/main.go
@@ -55,10 +55,15 @@ func main() {
 	var dedup *deduplicator
 	if *deduplicationInterval > 0 {
 		maxSize := resolveDeduplicatorMaxSize()
-		if maxSize <= 0 {
-			logger.Fatalf("deduplicator maxSize must be greater than 0; set -deduplication.maxSize or -deduplication.maxSizeBytes")
+		if maxSize <= deduplicationMinMaxSize {
+			logger.Fatalf("deduplicator maxSize must be greater than %d; got %d. Set -deduplication.maxSize or -deduplication.maxSizeBytes", maxSize, deduplicationMinMaxSize)
 		}
-		dedup = newDeduplicator(maxSize, *deduplicationInterval)
+		interval := *deduplicationInterval
+		if interval < deduplicationMinInterval {
+			logger.Fatalf("deduplication interval must be greater than %v; got %v", deduplicationMinInterval, interval)
+		}
+
+		dedup = newDeduplicator(maxSize, interval)
 		defer dedup.Stop()
 		passthroughThreshold := maxSize * 4 / 5
 		logger.Infof("deduplicator enabled: interval=%s maxSize=%d passthroughThreshold=%d sizeBytes=%d", *deduplicationInterval, maxSize, passthroughThreshold, maxSize*bitsPerItem/8)

--- a/app/vmestimator/main.go
+++ b/app/vmestimator/main.go
@@ -60,7 +60,7 @@ func main() {
 		}
 		dedup = newDeduplicator(maxSize, *deduplicationInterval)
 		defer dedup.Stop()
-		logger.Infof("deduplicator enabled: interval=%s maxSize=%d", *deduplicationInterval, maxSize)
+		logger.Infof("deduplicator enabled: interval=%s maxSize=%d sizeBytes=%d", *deduplicationInterval, maxSize, maxSize*bitsPerItem/8)
 	}
 
 	if *cardinalityMetricsExposeAt == `/metrics` {

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -16,7 +16,7 @@ Metrics of the latest version of vmestimator cluster are available for viewing a
 
 ## tip
 
-* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add time series deduplicator to drop duplicate series within a configurable time window before forwarding to estimators. Use `-deduplication.interval` to enable it, `-deduplication.maxSizeBytes` or `-deduplication.maxSize` to cap memory usage. When true cardinality exceeds the limit, the deduplicator gradually falls back to pass-through mode instead of failing hard. See [#44](https://github.com/VictoriaMetrics/vmestimator/pull/44).
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add time series deduplicator to drop duplicate series within a configurable time window before forwarding to estimators. Use `-deduplication.interval` to enable it, `-deduplication.maxSizeBytes` or `-deduplication.maxSize` to cap memory usage. When cardinality approaches 80% of the limit, the deduplicator gradually falls back to pass-through mode to keep bloom filters below saturation. See [#44](https://github.com/VictoriaMetrics/vmestimator/pull/44).
 
 ## [v0.1.14](https://github.com/VictoriaMetrics/vmestimator/releases/tag/v0.1.14)
 

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -16,6 +16,8 @@ Metrics of the latest version of vmestimator cluster are available for viewing a
 
 ## tip
 
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add time series deduplicator to drop duplicate series within a configurable time window before forwarding to estimators. Use `-deduplication.interval` to enable it, `-deduplication.maxSizeBytes` or `-deduplication.maxSize` to cap memory usage. When true cardinality exceeds the limit, the deduplicator gradually falls back to pass-through mode instead of failing hard. See [#44](https://github.com/VictoriaMetrics/vmestimator/pull/44).
+
 ## [v0.1.14](https://github.com/VictoriaMetrics/vmestimator/releases/tag/v0.1.14)
 
 * FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add `-workers` flag for processing time series insertions concurrently. This improves throughput under high ingestion load. See [#42](https://github.com/VictoriaMetrics/vmestimator/pull/42).

--- a/docs/vmestimator/vmestimator.md
+++ b/docs/vmestimator/vmestimator.md
@@ -487,10 +487,6 @@ When the true number of unique series exceeds 80% of the configured limit, the d
 This prevents bloom filter saturation (which would cause false positives) and keeps memory usage bounded.
 The pass-through ratio is logged whenever it changes:
 
-```
-deduplicator: unique series estimate=1200000 maxSize=1000000 passthrough=167/1000
-```
-
 A ratio of `0/1000` means full deduplication; `1000/1000` means all series pass through unchanged.
 
 ## Dashboards

--- a/docs/vmestimator/vmestimator.md
+++ b/docs/vmestimator/vmestimator.md
@@ -456,6 +456,43 @@ Additionally, every stream (including non-grouped ones) exposes:
 - `vmestimator_estimator_insert_total{group_by_keys, interval, filter}` — total number of samples inserted into this stream's estimator (only counts series that passed the `filter`)
 
 
+## Deduplication
+
+Processing each time series is CPU-intensive: vmestimator must iterate over all labels, resolve group-by values, and call HLL insert for every estimator.
+For `__label__` streams it is even more expensive, as HLL insert is called once per label per series.
+
+Scraped time series are mostly identical between scrapes on short intervals.
+Once a series has been seen, re-processing it within the same window does not change the cardinality estimate.
+Deduplication exploits this by dropping already-seen series before they reach the estimators, reducing CPU usage without affecting accuracy.
+
+Enable deduplication with `-deduplication.interval`:
+
+```bash
+/path/to/vmestimator -config=streams.yaml -deduplication.interval=2m
+```
+
+When enabled, vmestimator tracks which time series it has already seen within the configured window using bloom filters.
+Series seen within the window are dropped before reaching the estimators.
+Set the interval 3–5× lower than the shortest estimator interval to ensure estimates remain accurate.
+
+**Memory budget**
+
+By default, the deduplicator uses 5% of the allowed memory (see `-memory.allowedBytes` / `-memory.allowedPercent`).
+To set an explicit limit use `-deduplication.maxSizeBytes` (e.g. `100MB`) or `-deduplication.maxSize` (number of unique series).
+When both flags are set, the stricter limit applies.
+
+**Overflow behaviour**
+
+When the true number of unique series exceeds 80% of the configured limit, the deduplicator gradually switches to pass-through mode for the excess series.
+This prevents bloom filter saturation (which would cause false positives) and keeps memory usage bounded.
+The pass-through ratio is logged whenever it changes:
+
+```
+deduplicator: unique series estimate=1200000 maxSize=1000000 passthrough=167/1000
+```
+
+A ratio of `0/1000` means full deduplication; `1000/1000` means all series pass through unchanged.
+
 ## Dashboards
 
 Two Grafana dashboards are available in the [dashboards](https://github.com/VictoriaMetrics/vmestimator/tree/main/dashboards) directory:
@@ -512,6 +549,13 @@ Usage of ./bin/vmestimator:
         Minimum cardinality estimate to expose. Estimates below this threshold are suppressed to reduce metric volume and noise. Set to 0 to expose all estimates (default 0).
   -config string
         Path to YAML configuration file. Must be set unless -storageNode is specified. See https://github.com/VictoriaMetrics/vmestimator/blob/main/streams.yaml for config example
+  -deduplication.interval duration
+        Time window for deduplication. When set, time series already seen within the window are dropped before being forwarded to estimators. Disabled when set to 0.
+  -deduplication.maxSize int
+        Maximum number of unique time series the deduplicator tracks. Pass-through begins at 80% of this limit so bloom filters never saturate and start producing false positives. Defaults to a value derived from 5 percent of allowed memory. When both -deduplication.maxSizeBytes and -deduplication.maxSize are set, the stricter limit is used.
+  -deduplication.maxSizeBytes size
+        Memory budget for deduplication bloom filters, e.g. 100MB. Controls how many unique time series can be tracked before the deduplicator gradually switches to pass-through mode. Pass-through starts at 80% of the limit to keep bloom filters well below saturation. Defaults to 5 percent of allowed memory. When both -deduplication.maxSizeBytes and -deduplication.maxSize are set, the stricter limit is used.
+        Supports the following optional suffixes for size values: KB, MB, GB, TB, KiB, MiB, GiB, TiB (default 0)
   -enableTCP6
         Whether to enable IPv6 for listening and dialing. By default, only IPv4 TCP and UDP are used
   -envflag.enable


### PR DESCRIPTION
Adds an optional deduplicator that sits in front of estimators and drops time series already seen within a configured interval, reducing estimator CPU and memory pressure when the same series are sent repeatedly.

Enabled by setting `-deduplication.interval` (e.g. `-deduplication.interval=1m`). Memory usage is controlled via `-deduplication.maxSizeBytes` or `-deduplication.maxSize` (defaults to 5% of allowed memory).

Internally uses 10 bloom filter buckets — each series maps to one bucket by fingerprint%10. One bucket is cleared every interval/10 on a fixed wall-clock grid, spreading the reset cost evenly over time.

A HyperLogLog sketch tracks true inbound cardinality. When it exceeds the configured limit, the deduplicator gradually passes through the excess proportionally: at 2x the limit, 50% of series bypass deduplication. During cardinality spikes, the estimator will consume more CPU as a result, which is expected.