### PR TITLE
Add per-stream min_cardinality config field

### DIFF
--- a/app/vmestimator/config.go
+++ b/app/vmestimator/config.go
@@ -27,6 +27,11 @@ type EstimatorConfig struct {
 	Buckets      int               `yaml:"buckets"`
 	HLLPrecision uint8             `yaml:"hll_precision"`
 	HLLSparse    *bool             `yaml:"hll_sparse"`
+
+	// MinCardinality, when non-nil, overrides the global
+	// -cardinalityMetrics.minCardinality flag for this stream only.
+	// When nil, the global flag value is used.
+	MinCardinality *uint64 `yaml:"min_cardinality"`
 }
 
 func loadConfig(path string) ([]*estimator, error) {

--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -28,6 +28,8 @@ type estimator struct {
 
 	hasLabelKeyword bool
 
+	minCardinality *uint64
+
 	buckets []*estimatorBucket
 
 	metricsSet  *metrics.Set
@@ -82,6 +84,7 @@ func newEstimator(cfg EstimatorConfig) (*estimator, error) {
 		groupBy:         cfg.GroupBy,
 		hasLabelKeyword: len(cfg.GroupBy) > 0 && cfg.GroupBy[len(cfg.GroupBy)-1] == labelKeyword,
 		compiledFilter:  cf,
+		minCardinality:  cfg.MinCardinality,
 		groupSize: &groupSize{
 			limit:          int64(cfg.GroupLimit),
 			bucketSizes:    make([]int64, cfg.Buckets),
@@ -287,6 +290,7 @@ func (e *estimator) toSnapshot(cb func(s *snapshot) error) error {
 		s.Filter = eb0.filter
 		s.Labels = eb0.labels
 		s.GroupBy = nil
+		s.MinCardinality = e.minCardinality
 		return cb(s)
 	}
 
@@ -298,6 +302,7 @@ func (e *estimator) toSnapshot(cb func(s *snapshot) error) error {
 	s.Interval = eb0.interval
 	s.Filter = eb0.filter
 	s.Labels = eb0.labels
+	s.MinCardinality = e.minCardinality
 
 	skp := newSketchesPool(eb0.precision, min(batchSize, eb0.groupSize.avgBucketSize()))
 	keys := make([]uint64, 0, batchSize)
@@ -390,11 +395,12 @@ func (e *estimator) writeMetrics(w io.Writer) {
 	if len(e.groupBy) > 0 {
 		eb0 := e.buckets[0]
 		s := &snapshot{
-			GroupBy:    eb0.groupBy,
-			Interval:   eb0.interval,
-			Filter:     eb0.filter,
-			Labels:     eb0.labels,
-			GroupLimit: eb0.groupSize.limit,
+			GroupBy:        eb0.groupBy,
+			Interval:       eb0.interval,
+			Filter:         eb0.filter,
+			Labels:         eb0.labels,
+			GroupLimit:     eb0.groupSize.limit,
+			MinCardinality: e.minCardinality,
 		}
 		if dropped > 0 {
 			if err := s.writeDroppedMetric(w, dropped); err != nil {

--- a/app/vmestimator/snapshot.go
+++ b/app/vmestimator/snapshot.go
@@ -62,6 +62,10 @@ type snapshot struct {
 	GroupLimit      int64
 	GroupRejectSize int64
 
+	// MinCardinality, when non-nil, overrides the global
+	// -cardinalityMetrics.minCardinality flag for this stream.
+	MinCardinality *uint64
+
 	// prom string metric => hll
 	Sketches map[uint64]SnapshotSketch
 }
@@ -128,6 +132,7 @@ func (s *snapshot) merge(other *snapshot) {
 	s.GroupBy = append(s.GroupBy[:0], other.GroupBy...)
 	s.GroupLimit = other.GroupLimit
 	s.GroupRejectSize += other.GroupRejectSize
+	s.MinCardinality = other.MinCardinality
 }
 
 func (s *snapshot) writeMetrics(w io.Writer) error {
@@ -177,10 +182,15 @@ func (s *snapshot) writeCardinalityEstimates(w io.Writer) (uint64, error) {
 	groupByKeysLabelB := appendGroupByKeysLabel(make([]byte, 0, 128), `group_by_keys`, s.GroupBy)
 	groupByKeysLabel := bytesutil.ToUnsafeString(groupByKeysLabelB)
 
+	threshold := *cardinalityMetricsMinCardinality
+	if s.MinCardinality != nil {
+		threshold = *s.MinCardinality
+	}
+
 	var dropped uint64
 	for _, ssk := range s.Sketches {
 		estimate := ssk.Sketch.Estimate()
-		if estimate < *cardinalityMetricsMinCardinality {
+		if estimate < threshold {
 			dropped++
 			continue
 		}
@@ -290,6 +300,7 @@ func (s *snapshot) reset() {
 	s.Interval = 0
 	s.Filter = ""
 	s.GroupBy = s.GroupBy[:0]
+	s.MinCardinality = nil
 	clear(s.Labels)
 	clear(s.Sketches)
 }

--- a/app/vmestimator/snapshot_test.go
+++ b/app/vmestimator/snapshot_test.go
@@ -682,3 +682,142 @@ func TestMinCardinalityFilter(t *testing.T) {
 		t.Fatalf("dropped metric with count=1 must be present in output\noutput:\n%s", out)
 	}
 }
+
+func TestPerStreamMinCardinality(t *testing.T) {
+	orig := *cardinalityMetricsMinCardinality
+	defer func() {
+		*cardinalityMetricsMinCardinality = orig
+	}()
+
+	// Global flag set high — would normally suppress both groups.
+	*cardinalityMetricsMinCardinality = 100
+
+	// Stream with per-stream override of 0 → expose all estimates.
+	zero := uint64(0)
+	e, err := newEstimator(EstimatorConfig{
+		Interval:       time.Minute * 10,
+		GroupBy:        []string{"foo"},
+		Buckets:        3,
+		MinCardinality: &zero,
+	})
+	if err != nil {
+		t.Fatalf("newEstimator: %v", err)
+	}
+	defer e.stop()
+
+	var tss []protoparser.TimeSerie
+	for i := 0; i < 99; i++ {
+		tss = append(tss, protoparser.TimeSerie{
+			Labels: []protoparser.Label{
+				{Name: "foo", Value: "low"},
+				{Name: "i", Value: strconv.Itoa(i)},
+			},
+			Fingerprint: hash([]byte(fmt.Sprintf("foo=low,i=%d", i))),
+		})
+	}
+	for i := 0; i < 100; i++ {
+		tss = append(tss, protoparser.TimeSerie{
+			Labels: []protoparser.Label{
+				{Name: "foo", Value: "high"},
+				{Name: "i", Value: strconv.Itoa(i)},
+			},
+			Fingerprint: hash([]byte(fmt.Sprintf("foo=high,i=%d", i))),
+		})
+	}
+	e.insertMany(tss)
+
+	s := newSnapshot()
+	if err := e.toSnapshot(func(batchS *snapshot) error {
+		s.merge(batchS)
+		return nil
+	}); err != nil {
+		t.Fatalf("toSnapshot: %v", err)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := s.writeMetrics(buf); err != nil {
+		t.Fatalf("writeMetrics: %v", err)
+	}
+	out := buf.String()
+
+	// Per-stream override of 0 should expose BOTH groups despite global=100.
+	if !regexp.MustCompile(`by_foo="low"`).MatchString(out) {
+		t.Fatalf("low-cardinality group must be present with per-stream override=0\noutput:\n%s", out)
+	}
+	if !regexp.MustCompile(`by_foo="high"`).MatchString(out) {
+		t.Fatalf("high-cardinality group must be present\noutput:\n%s", out)
+	}
+	// No dropped metric since per-stream threshold is 0.
+	if strings.Contains(out, "vmestimator_cardinality_estimates_dropped") {
+		t.Fatalf("dropped metric must not be present when per-stream threshold=0\noutput:\n%s", out)
+	}
+}
+
+func TestPerStreamMinCardinalityHigherThanGlobal(t *testing.T) {
+	orig := *cardinalityMetricsMinCardinality
+	defer func() {
+		*cardinalityMetricsMinCardinality = orig
+	}()
+
+	// Global flag set to 0 (expose all).
+	*cardinalityMetricsMinCardinality = 0
+
+	// Stream with per-stream override of 100 → suppress low groups.
+	threshold := uint64(100)
+	e, err := newEstimator(EstimatorConfig{
+		Interval:       time.Minute * 10,
+		GroupBy:        []string{"foo"},
+		Buckets:        3,
+		MinCardinality: &threshold,
+	})
+	if err != nil {
+		t.Fatalf("newEstimator: %v", err)
+	}
+	defer e.stop()
+
+	var tss []protoparser.TimeSerie
+	for i := 0; i < 99; i++ {
+		tss = append(tss, protoparser.TimeSerie{
+			Labels: []protoparser.Label{
+				{Name: "foo", Value: "low"},
+				{Name: "i", Value: strconv.Itoa(i)},
+			},
+			Fingerprint: hash([]byte(fmt.Sprintf("foo=low,i=%d", i))),
+		})
+	}
+	for i := 0; i < 100; i++ {
+		tss = append(tss, protoparser.TimeSerie{
+			Labels: []protoparser.Label{
+				{Name: "foo", Value: "high"},
+				{Name: "i", Value: strconv.Itoa(i)},
+			},
+			Fingerprint: hash([]byte(fmt.Sprintf("foo=high,i=%d", i))),
+		})
+	}
+	e.insertMany(tss)
+
+	s := newSnapshot()
+	if err := e.toSnapshot(func(batchS *snapshot) error {
+		s.merge(batchS)
+		return nil
+	}); err != nil {
+		t.Fatalf("toSnapshot: %v", err)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := s.writeMetrics(buf); err != nil {
+		t.Fatalf("writeMetrics: %v", err)
+	}
+	out := buf.String()
+
+	// Per-stream override of 100 should suppress "low" group despite global=0.
+	if strings.Contains(out, `by_foo="low"`) {
+		t.Fatalf("low-cardinality group must be suppressed by per-stream minCardinality=100\noutput:\n%s", out)
+	}
+	if !regexp.MustCompile(`by_foo="high"`).MatchString(out) {
+		t.Fatalf("high-cardinality group must be present\noutput:\n%s", out)
+	}
+	if !regexp.MustCompile(`vmestimator_cardinality_estimates_dropped\{[^}]+\} 1`).MatchString(out) {
+		t.Fatalf("dropped metric with count=1 must be present\noutput:\n%s", out)
+	}
+}

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -16,6 +16,8 @@ Metrics of the latest version of vmestimator cluster are available for viewing a
 
 ## tip
 
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add per-stream `min_cardinality` config field to override the global `-cardinalityMetrics.minCardinality` flag for individual streams. When unset, the global flag value is used. See [#46](https://github.com/VictoriaMetrics/vmestimator/issues/46).
+
 ## [v0.1.15](https://github.com/VictoriaMetrics/vmestimator/releases/tag/v0.1.15)
 
 Released at 2026-08-17

--- a/docs/vmestimator/vmestimator.md
+++ b/docs/vmestimator/vmestimator.md
@@ -237,6 +237,24 @@ Use `-cardinalityMetrics.minCardinality=N` to suppress group-by cardinality esti
 This is useful when `group_by` produces many low-cardinality groups that add noise without actionable signal.
 When groups are suppressed, the `vmestimator_cardinality_estimates_dropped` metric reports the number of dropped groups per stream.
 
+The global flag applies the same threshold to every stream. To override it per stream — for example to
+keep low-cardinality estimates from a `__label__` stream while suppressing noise from high-cardinality
+streams — set the `min_cardinality` field on individual streams:
+
+```yaml
+streams:
+  - group_by: [__name__, job, region]
+    interval: 5m
+    min_cardinality: 1000
+
+  - group_by: [__label__]
+    interval: 5m
+    # min_cardinality unset → falls back to the global flag
+```
+
+When `min_cardinality` is set on a stream, it overrides the global flag for that stream only.
+When unset, the global flag value is used.
+
 Computing cardinality estimates is expensive, so results are cached.
 Cache duration is controlled by `-cardinalityMetrics.cacheTTL` (default: `30s`).
 Set to `0` to disable caching entirely.


### PR DESCRIPTION
## Summary

Adds a per-stream `min_cardinality` config field that overrides the global `-cardinalityMetrics.minCardinality` flag for individual streams.

Closes #46.

## Motivation

The global `-cardinalityMetrics.minCardinality` flag (added in #41) applies the same threshold to every group-by stream. This suppresses estimates from streams where low cardinality is **expected and meaningful** — most notably the `__label__` group-by keyword (#26), which emits one estimate per label name. Many label names legitimately have very low cardinality (e.g. `bar=1`, `status=2`), and a global threshold high enough to clean up high-cardinality streams silently drops those intentional estimates.

## Changes

- `config.go`: add `MinCardinality *uint64` field to `EstimatorConfig`
- `estimator.go`: store per-stream threshold, pass it through to snapshots
- `snapshot.go`: use per-stream threshold in `writeCardinalityEstimates` when set; fall back to global flag when nil. Handle in `merge`/`reset` for the storage-node merge path.
- Tests: `TestPerStreamMinCardinality` (override=0 exposes all despite global=100) and `TestPerStreamMinCardinalityHigherThanGlobal` (override=100 suppresses despite global=0)
- Docs: updated `vmestimator.md` and `CHANGELOG.md`

## Usage

```yaml
streams:
  - group_by: [__name__, job, region]
    interval: 5m
    min_cardinality: 1000

  - group_by: [__label__]
    interval: 5m
    # min_cardinality unset → falls back to global flag
```

Precedence: stream-level `min_cardinality` > global `-cardinalityMetrics.minCardinality` flag > 0 (default).