### PR TITLE
deduplicator: simplify overflow handling and add metrics

### DIFF
--- a/app/vmestimator/deduplicator.go
+++ b/app/vmestimator/deduplicator.go
@@ -133,6 +133,8 @@ func (d *deduplicator) filter(src, dst []protoparser.TimeSerie) []protoparser.Ti
 }
 
 func (d *deduplicator) Stop() {
+	metrics.UnregisterMetric(`vmestimator_deduplication_bloom_filter_max_size`)
+	metrics.UnregisterMetric(`vmestimator_deduplication_bloom_filter_size`)
 	close(d.stopCh)
 }
 

--- a/app/vmestimator/deduplicator.go
+++ b/app/vmestimator/deduplicator.go
@@ -7,9 +7,14 @@ import (
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/flagutil"
-	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/memory"
+	"github.com/VictoriaMetrics/metrics"
 	"github.com/VictoriaMetrics/vmestimator/app/vmestimator/protoparser"
+)
+
+var (
+	deduplicationPassedTotal  = metrics.NewCounter(`vmestimator_deduplication_passed_total`)
+	deduplicationDroppedTotal = metrics.NewCounter(`vmestimator_deduplication_dropped_total`)
 )
 
 var (
@@ -57,16 +62,6 @@ type deduplicator struct {
 	// smoothing CPU spikes across time.
 	bfs [10]atomic.Pointer[deduplicatorBloomFilter]
 
-	// e estimates the true unique-series count using an estimator in global
-	// mode (no group_by). Its sharded buckets avoid any global lock on the
-	// write path.
-	e *estimator
-
-	// Gradual pass-through ratio stored per-1000.
-	// 0 = deduplicate all; 1000 = pass everything through.
-	// When unique > maxSize, ratio = (unique - maxSize) * 1000 / unique.
-	passthroughPer1000 atomic.Int64
-
 	stopCh chan struct{}
 }
 
@@ -83,26 +78,27 @@ func newDeduplicator(maxSize int, interval time.Duration) *deduplicator {
 		panic(fmt.Sprintf("BUG: interval must be greater than %v; got %v", deduplicationMinInterval, interval))
 	}
 
-	e, err := newEstimator(EstimatorConfig{
-		Interval:     interval,
-		HLLSparse:    new(false),
-		HLLPrecision: 12,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("BUG: cannot create deduplicator estimator: %s", err))
-	}
-
 	d := &deduplicator{
 		maxSize:       maxSize,
 		interval:      interval,
 		bucketMaxSize: maxSize / 10,
-		e:             e,
 		stopCh:        make(chan struct{}),
 	}
 
 	for i := range d.bfs {
 		d.bfs[i].Store(newDeduplicatorBloomFilter(d.bucketMaxSize))
 	}
+
+	metrics.NewGauge(`vmestimator_deduplication_bloom_filter_max_size`, func() float64 {
+		return float64(d.maxSize)
+	})
+	metrics.NewGauge(`vmestimator_deduplication_bloom_filter_size`, func() float64 {
+		var total int64
+		for i := range d.bfs {
+			total += d.bfs[i].Load().size.Load()
+		}
+		return float64(total)
+	})
 
 	go d.runRotation()
 	return d
@@ -116,41 +112,32 @@ func (d *deduplicator) filter(src, dst []protoparser.TimeSerie) []protoparser.Ti
 		return dst
 	}
 
-	// Update the estimator with every incoming series before filtering, so
-	// cardinality estimates reflect true inbound volume regardless of deduplication
-	// decisions.
-	d.e.insertMany(src)
-
-	passthrough := d.passthroughPer1000.Load()
-
 	for i := range src {
 		ts := src[i]
 		h := ts.Fingerprint
 
-		// Overflow pass-through: deterministic by hash so the same series
-		// always lands on the same side of the split.
-		if passthrough > 0 && int64(h%1000) < passthrough {
-			dst = append(dst, ts)
+		bf := d.bfs[h%10].Load()
+		if bf.contains(h) {
+			deduplicationDroppedTotal.Inc()
 			continue
 		}
 
-		bf := d.bfs[h%10].Load()
-		if !bf.contains(h) {
+		bfSize := bf.size.Load()
+		if bfSize < int64(d.bucketMaxSize) {
 			bf.add(h)
-			dst = append(dst, ts)
 		}
+		deduplicationPassedTotal.Inc()
+		dst = append(dst, ts)
 	}
 	return dst
 }
 
 func (d *deduplicator) Stop() {
 	close(d.stopCh)
-	d.e.stop()
 }
 
 func (d *deduplicator) runRotation() {
 	bucketDur := d.interval / 10
-	var prevRatio int64
 
 	for {
 		now := time.Now()
@@ -165,25 +152,6 @@ func (d *deduplicator) runRotation() {
 
 		idx := (nextBoundary.UnixNano() / int64(bucketDur)) % 10
 		d.bfs[idx].Store(newDeduplicatorBloomFilter(d.bucketMaxSize))
-
-		// Recalculate pass-through ratio after each bucket rotation.
-		// The estimator handles its own sketch rotation; we just read the estimate.
-		unique := d.e.estimate()
-
-		// Start pass-through at 80% of maxSize so the bloom filters never
-		// reach saturation: at full capacity false-positive rate spikes,
-		// which would silently drop legitimate new series.
-		passthroughThreshold := uint64(d.maxSize) * 4 / 5
-		var ratio int64
-		if unique > passthroughThreshold {
-			ratio = int64((unique - passthroughThreshold) * 1000 / unique)
-		}
-		d.passthroughPer1000.Store(ratio)
-
-		if ratio != prevRatio {
-			prevRatio = ratio
-			logger.Infof("deduplicator: unique series estimate=%d maxSize=%d passthrough=%d/1000", unique, d.maxSize, ratio)
-		}
 	}
 }
 
@@ -191,6 +159,7 @@ const hashesCount = 4
 const bitsPerItem = 16
 
 type deduplicatorBloomFilter struct {
+	size atomic.Int64
 	bits []uint64
 }
 
@@ -245,6 +214,10 @@ func (f *deduplicatorBloomFilter) add(h uint64) bool {
 			}
 			w = atomic.LoadUint64(&bits[word])
 		}
+	}
+
+	if isNew {
+		f.size.Add(1)
 	}
 	return isNew
 }

--- a/app/vmestimator/deduplicator_test.go
+++ b/app/vmestimator/deduplicator_test.go
@@ -129,4 +129,3 @@ func TestDeduplicator_filterSaturated(t *testing.T) {
 		t.Fatalf("saturated: expected pass-through on second call, got %v", got)
 	}
 }
-

--- a/app/vmestimator/deduplicator_test.go
+++ b/app/vmestimator/deduplicator_test.go
@@ -90,43 +90,43 @@ func TestDeduplicator_filter(t *testing.T) {
 	f(tss, makeTSS(1, 2, 3))
 }
 
-func TestDeduplicator_filterPassthrough(t *testing.T) {
+func TestDeduplicator_filterSaturated(t *testing.T) {
+	// Use minimum valid maxSize so bucketMaxSize=1_000, keeping the test fast.
 	d := newDeduplicator(10_000, time.Hour)
 	defer d.Stop()
 
-	makeTSS := func(fps ...uint64) []protoparser.TimeSerie {
-		tss := make([]protoparser.TimeSerie, len(fps))
-		for i, fp := range fps {
-			tss[i] = protoparser.TimeSerie{Fingerprint: fp}
-		}
-		return tss
+	// Saturate bucket 1 (fp%10 == 1) by inserting bucketMaxSize unique series.
+	for i := uint64(0); i < uint64(d.bucketMaxSize); i++ {
+		fp := i*10 + 1
+		d.filter([]protoparser.TimeSerie{{Fingerprint: fp}}, nil)
 	}
 
-	f := func(src, exp []protoparser.TimeSerie) {
-		t.Helper()
-		dst := d.filter(src, nil)
-		if !reflect.DeepEqual(dst, exp) {
-			t.Fatalf("filter: expected %v, got %v", exp, dst)
-		}
+	bf1 := d.bfs[1].Load()
+	if got := bf1.size.Load(); got != int64(d.bucketMaxSize) {
+		t.Fatalf("expected bucket 1 saturated at size=%d, got %d", d.bucketMaxSize, got)
 	}
 
-	// Build a batch that spans both sides of the 500 threshold.
-	// fp%1000: 1,101,201,301,401 < 500 (pass); 501,601,701,801,901 >= 500 (no pass).
-	tss := makeTSS(1, 101, 201, 301, 401, 501, 601, 701, 801, 901)
+	// Pick a new fp that maps to bucket 1 and is outside the seeded range.
+	newFP := uint64(d.bucketMaxSize)*10 + 1
+	if bf1.contains(newFP) {
+		t.Fatalf("newFP=%d is a false positive in the bloom filter; choose a different value", newFP)
+	}
 
-	// Seed BF so all series are "already seen".
-	d.filter(tss, nil)
-	f(tss, nil)
+	newTSS := []protoparser.TimeSerie{{Fingerprint: newFP}}
 
-	// Full passthrough: all series pass regardless of BF state.
-	d.passthroughPer1000.Store(1000)
-	f(tss, tss)
+	// Saturated bucket: unseen series passes through but is NOT added to the BF.
+	got := d.filter(newTSS, nil)
+	if !reflect.DeepEqual(got, newTSS) {
+		t.Fatalf("saturated: expected pass-through, got %v", got)
+	}
+	if bf1.size.Load() != int64(d.bucketMaxSize) {
+		t.Fatal("saturated: series was incorrectly added to the bloom filter")
+	}
 
-	// 50% passthrough: only series with fp%1000 < 500 pass through.
-	d.passthroughPer1000.Store(500)
-	exp := makeTSS(1, 101, 201, 301, 401)
-	f(tss, exp)
-
-	// Passthrough decision is deterministic: repeated calls yield the same result.
-	f(tss, exp)
+	// Second call: same series passes through again because it was never recorded.
+	got = d.filter(newTSS, nil)
+	if !reflect.DeepEqual(got, newTSS) {
+		t.Fatalf("saturated: expected pass-through on second call, got %v", got)
+	}
 }
+

--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -365,18 +365,6 @@ func (e *estimator) toSnapshot(cb func(s *snapshot) error) error {
 	return cb(s)
 }
 
-// estimate returns the current unique-series count by merging all bucket sketches.
-func (e *estimator) estimate() uint64 {
-	eb0 := e.buckets[0]
-	resSK := eb0.newSketch()
-	for _, eb := range e.buckets {
-		eb.mu.Lock()
-		eb.mergeSketches(eb.sketch, eb.prevSketch, resSK)
-		eb.mu.Unlock()
-	}
-	return resSK.Estimate()
-}
-
 func (e *estimator) writeMetrics(w io.Writer) {
 	var dropped uint64
 	if err := e.toSnapshot(func(s *snapshot) error {

--- a/app/vmestimator/main.go
+++ b/app/vmestimator/main.go
@@ -90,7 +90,6 @@ func main() {
 			writeCardinalityMetrics(w, es, *storageNodes)
 			return true
 		}
-
 		path, _ := strings.CutPrefix(r.URL.Path, `/cardinality`)
 		switch path {
 		case "/api/v1/write":

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -16,6 +16,8 @@ Metrics of the latest version of vmestimator cluster are available for viewing a
 
 ## tip
 
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): simplify overflow handling in the deduplicator. Expose `vmestimator_deduplication_passed_total`, `vmestimator_deduplication_dropped_total`, `vmestimator_deduplication_bloom_filter_size`, and `vmestimator_deduplication_bloom_filter_max_size` metrics for monitoring deduplication effectiveness. See [#48](https://github.com/VictoriaMetrics/vmestimator/pull/48).
+
 ## [v0.1.15](https://github.com/VictoriaMetrics/vmestimator/releases/tag/v0.1.15)
 
 Released at 2026-08-17


### PR DESCRIPTION
  Replace the HLL-estimator-based passthrough ratio with a simpler
  saturation guard: when a bloom filter bucket is full, new series
  pass through without being added. This avoids the overhead of a
  parallel estimator and the complexity of ratio-based pass-through.

  Add Prometheus metrics for visibility:
  - vmestimator_deduplication_passed_total
  - vmestimator_deduplication_dropped_total
  - vmestimator_deduplication_bloom_filter_size
  - vmestimator_deduplication_bloom_filter_max_size

  Track exact bloom filter occupancy via atomic size counter on each
  bucket, used both for saturation checks and for the new gauge metric.
