### PR TITLE
app/vmestimator: add churn_interval stream config option

### DIFF
--- a/app/vmestimator/cardinality_metrics.go
+++ b/app/vmestimator/cardinality_metrics.go
@@ -13,6 +13,7 @@ import (
 	"github.com/VictoriaMetrics/metrics"
 )
 
+// globalChurnSnapshots must be accessed only under cardinalityCacheMu.
 var globalChurnSnapshots = newChurnSnapshots()
 
 var (

--- a/app/vmestimator/cardinality_metrics.go
+++ b/app/vmestimator/cardinality_metrics.go
@@ -13,6 +13,8 @@ import (
 	"github.com/VictoriaMetrics/metrics"
 )
 
+var globalChurnSnapshots = newChurnSnapshots()
+
 var (
 	cardinalityMetricsWrites        = metrics.NewCounter(`vmestimator_write_cardinality_metrics_total`)
 	cardinalityMetricsWriteDuration = metrics.NewFloatCounter(`vmestimator_write_cardinality_metrics_duration_seconds_total`)
@@ -36,11 +38,39 @@ func writeCardinalityMetrics(w io.Writer, es []*estimator, storageNodeURLs []str
 
 	cardinalityCacheMu.Lock()
 	if time.Since(cardinalityMetricsCacheAt) >= *cardinalityMetricsCacheTTL || *cardinalityMetricsCacheTTL == 0 {
+		now := time.Now()
 		plain := bytes.NewBuffer(cardinalityMetricsCache[:0])
 		for _, e := range es {
-			e.writeMetrics(plain)
+			var dropped uint64
+			if err := e.toSnapshot(func(s *snapshot) error {
+				if s.ChurnInterval > 0 {
+					globalChurnSnapshots.update(s, now)
+				}
+				d, err := s.writeCardinalityEstimates(plain)
+				dropped += d
+				return err
+			}); err != nil {
+				logger.Errorf("writing metrics failed: %s; written cardinality metrics might be incomplete or invalid", err)
+			}
+			if len(e.groupBy) > 0 {
+				eb0 := e.buckets[0]
+				s := &snapshot{
+					GroupBy:    eb0.groupBy,
+					Interval:   eb0.interval,
+					Filter:     eb0.filter,
+					Labels:     eb0.labels,
+					GroupLimit: eb0.groupSize.limit,
+				}
+				if dropped > 0 {
+					if err := s.writeDroppedMetric(plain, dropped); err != nil {
+						logger.Errorf("writing metrics failed: %s; written cardinality metrics might be incomplete or invalid", err)
+					}
+				}
+				if err := s.writeGroupSizeAndLimit(plain, eb0.groupSize.totalSize()); err != nil {
+					logger.Errorf("writing metrics failed: %s; written cardinality metrics might be incomplete or invalid", err)
+				}
+			}
 		}
-
 		if len(storageNodeURLs) > 0 {
 			ss := newSnapshots()
 			var wg sync.WaitGroup
@@ -55,9 +85,18 @@ func writeCardinalityMetrics(w io.Writer, es []*estimator, storageNodeURLs []str
 			}
 			wg.Wait()
 
+			for _, s := range ss.m {
+				if s.ChurnInterval > 0 {
+					globalChurnSnapshots.update(s, now)
+				}
+			}
+
 			if err := ss.writeMetrics(plain); err != nil {
 				logger.Errorf("write cardinality metrics: %s", err)
 			}
+		}
+		if err := globalChurnSnapshots.writeMetrics(plain); err != nil {
+			logger.Errorf("write churn metrics: %s", err)
 		}
 
 		cardinalityMetricsCache = plain.Bytes()

--- a/app/vmestimator/cardinality_metrics.go
+++ b/app/vmestimator/cardinality_metrics.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
@@ -56,6 +57,7 @@ func writeCardinalityMetrics(w io.Writer, es []*estimator, storageNodeURLs []str
 		}
 		if len(storageNodeURLs) > 0 {
 			ss := newSnapshots()
+			var fetchFailed atomic.Bool
 			var wg sync.WaitGroup
 			for _, nodeURL := range storageNodeURLs {
 				wg.Add(1)
@@ -63,14 +65,19 @@ func writeCardinalityMetrics(w io.Writer, es []*estimator, storageNodeURLs []str
 					defer wg.Done()
 					if err := fetchAndMergeSnapshots(url, ss.add); err != nil {
 						logger.Errorf("fetch snapshots from %s: %s", url, err)
+						fetchFailed.Store(true)
 					}
 				}(nodeURL)
 			}
 			wg.Wait()
 
-			for _, s := range ss.m {
-				if s.ChurnInterval > 0 {
-					globalChurnSnapshots.update(s, now)
+			// Update churn only when all nodes responded; a partial union would
+			// compare a full-cluster sketch against an incomplete one next scrape.
+			if !fetchFailed.Load() {
+				for _, s := range ss.m {
+					if s.ChurnInterval > 0 {
+						globalChurnSnapshots.update(s, now)
+					}
 				}
 			}
 

--- a/app/vmestimator/cardinality_metrics.go
+++ b/app/vmestimator/cardinality_metrics.go
@@ -42,33 +42,15 @@ func writeCardinalityMetrics(w io.Writer, es []*estimator, storageNodeURLs []str
 		now := time.Now()
 		plain := bytes.NewBuffer(cardinalityMetricsCache[:0])
 		for _, e := range es {
-			var dropped uint64
-			if err := e.toSnapshot(func(s *snapshot) error {
-				if s.ChurnInterval > 0 {
+			e.writeMetrics(plain)
+		}
+		for _, e := range es {
+			if e.buckets[0].churnInterval > 0 {
+				if err := e.toSnapshot(func(s *snapshot) error {
 					globalChurnSnapshots.update(s, now)
-				}
-				d, err := s.writeCardinalityEstimates(plain)
-				dropped += d
-				return err
-			}); err != nil {
-				logger.Errorf("writing metrics failed: %s; written cardinality metrics might be incomplete or invalid", err)
-			}
-			if len(e.groupBy) > 0 {
-				eb0 := e.buckets[0]
-				s := &snapshot{
-					GroupBy:    eb0.groupBy,
-					Interval:   eb0.interval,
-					Filter:     eb0.filter,
-					Labels:     eb0.labels,
-					GroupLimit: eb0.groupSize.limit,
-				}
-				if dropped > 0 {
-					if err := s.writeDroppedMetric(plain, dropped); err != nil {
-						logger.Errorf("writing metrics failed: %s; written cardinality metrics might be incomplete or invalid", err)
-					}
-				}
-				if err := s.writeGroupSizeAndLimit(plain, eb0.groupSize.totalSize()); err != nil {
-					logger.Errorf("writing metrics failed: %s; written cardinality metrics might be incomplete or invalid", err)
+					return nil
+				}); err != nil {
+					logger.Errorf("updating churn snapshots failed: %s", err)
 				}
 			}
 		}

--- a/app/vmestimator/cardinality_metrics.go
+++ b/app/vmestimator/cardinality_metrics.go
@@ -96,6 +96,7 @@ func writeCardinalityMetrics(w io.Writer, es []*estimator, storageNodeURLs []str
 				logger.Errorf("write cardinality metrics: %s", err)
 			}
 		}
+		globalChurnSnapshots.cleanup(now)
 		if err := globalChurnSnapshots.writeMetrics(plain); err != nil {
 			logger.Errorf("write churn metrics: %s", err)
 		}

--- a/app/vmestimator/churn.go
+++ b/app/vmestimator/churn.go
@@ -81,7 +81,7 @@ func (cs *churnSnapshots) update(s *snapshot, now time.Time) {
 
 		if e.curr == nil {
 			// First update: create an empty prev so rotation logic works normally,
-			// but churnRate will report 0 until prev has real data.
+			// but churnRatio will report 0 until prev has real data.
 			empty := ssk.Sketch.Clone()
 			empty.Reset()
 			e.prev = &churnSketch{addedAt: now, sketch: empty}
@@ -104,7 +104,7 @@ func (cs *churnSnapshots) cleanup(now time.Time) {
 	}
 }
 
-// writeMetrics writes cardinality_churn_rate metrics for all entries.
+// writeMetrics writes cardinality_churn_ratio metrics for all entries.
 // Churn rate is in [0, 1]. Reports 0 when prev has no data yet.
 func (cs *churnSnapshots) writeMetrics(w io.Writer) error {
 	buf := make([]byte, 0, 256)
@@ -112,7 +112,7 @@ func (cs *churnSnapshots) writeMetrics(w io.Writer) error {
 		metricPrefixB := appendChurnMetricPrefix(make([]byte, 0, 128), e.labels, e.interval, e.churnInterval, e.filter)
 		metricPrefix := bytesutil.ToUnsafeString(metricPrefixB)
 
-		rate := churnRate(e)
+		rate := churnRatio(e)
 		buf = buf[:0]
 		if len(e.groupBy) == 0 {
 			buf = append(buf, metricPrefix...)
@@ -131,9 +131,9 @@ func (cs *churnSnapshots) writeMetrics(w io.Writer) error {
 	return nil
 }
 
-// churnRate computes the churn rate for a churnEntry.
+// churnRatio computes the churn rate for a churnEntry.
 // Returns 0 when prev has no data yet.
-func churnRate(e *churnEntry) float64 {
+func churnRatio(e *churnEntry) float64 {
 	psk := e.prev.sketch
 	csk := e.curr.sketch
 	if psk.Estimate() == 0 {

--- a/app/vmestimator/churn.go
+++ b/app/vmestimator/churn.go
@@ -95,6 +95,15 @@ func (cs *churnSnapshots) update(s *snapshot, now time.Time) {
 	}
 }
 
+// cleanup removes entries whose curr sketch has not been updated within their 2*interval.
+func (cs *churnSnapshots) cleanup(now time.Time) {
+	for k, e := range cs.entries {
+		if e.curr.addedAt.Before(now.Add(-e.interval * 2)) {
+			delete(cs.entries, k)
+		}
+	}
+}
+
 // writeMetrics writes cardinality_churn_rate metrics for all entries.
 // Churn rate is in [0, 1]. Reports 0 when prev has no data yet.
 func (cs *churnSnapshots) writeMetrics(w io.Writer) error {

--- a/app/vmestimator/churn.go
+++ b/app/vmestimator/churn.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
+	"github.com/VictoriaMetrics/VictoriaMetrics/lib/logger"
+	"github.com/axiomhq/hyperloglog"
+)
+
+type churnKey struct {
+	snapshotKey string
+	groupKey    uint64
+}
+
+type churnEntry struct {
+	// metadata for writing metrics
+	interval      time.Duration
+	churnInterval time.Duration
+	filter        string
+	labels        map[string]string
+	groupBy       []string
+	values        []string // group label values for this groupKey
+
+	prev *churnSketch
+	curr   *churnSketch
+}
+
+type churnSketch struct {
+	addedAt time.Time
+	sketch  *hyperloglog.Sketch
+}
+
+// churnSnapshots holds prev and curr sketch baselines per (snapshotKey, groupKey).
+// When prev.addedAt < now-churnInterval, prev is reset to curr.
+// Must be accessed under its own mu lock.
+type churnSnapshots struct {
+	mu      sync.Mutex
+	entries map[churnKey]*churnEntry
+}
+
+func newChurnSnapshots() *churnSnapshots {
+	return &churnSnapshots{entries: make(map[churnKey]*churnEntry)}
+}
+
+// update accepts a single snapshot and upserts one churnEntry per group sketch.
+// Panics if s.ChurnInterval is zero.
+func (cs *churnSnapshots) update(s *snapshot, now time.Time) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	if s.ChurnInterval == 0 {
+		logger.Panicf("BUG: update called with snapshot with zero ChurnInterval")
+	}
+
+	snapKey := s.key()
+	for groupKey, ssk := range s.Sketches {
+		k := churnKey{snapshotKey: snapKey, groupKey: groupKey}
+
+		e, ok := cs.entries[k]
+		if !ok {
+			e = &churnEntry{
+				interval:      s.Interval,
+				churnInterval: s.ChurnInterval,
+				filter:        s.Filter,
+				groupBy:       append([]string{}, s.GroupBy...),
+				values:        append([]string{}, ssk.Values...),
+			}
+			if len(s.Labels) > 0 {
+				e.labels = make(map[string]string, len(s.Labels))
+				for lk, lv := range s.Labels {
+					e.labels[lk] = lv
+				}
+			}
+			cs.entries[k] = e
+		}
+
+		newSK := &churnSketch{
+			addedAt: now,
+			sketch:  ssk.Sketch.Clone(),
+		}
+
+		if e.curr == nil {
+			// First update: create an empty prev so rotation logic works normally,
+			// but churnRate will report 0 until prev has real data.
+			empty := ssk.Sketch.Clone()
+			empty.Reset()
+			e.prev = &churnSketch{addedAt: now, sketch: empty}
+			e.curr = newSK
+		} else if e.prev.addedAt.Before(now.Add(-s.ChurnInterval)) {
+			e.prev = &churnSketch{addedAt: now, sketch: e.curr.sketch}
+			e.curr = newSK
+		} else {
+			e.curr = newSK
+		}
+	}
+}
+
+// writeMetrics writes cardinality_churn_rate metrics for all entries.
+// Churn rate is in [0, 1]. Reports 0 when prev has no data yet.
+func (cs *churnSnapshots) writeMetrics(w io.Writer) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	buf := make([]byte, 0, 256)
+	for _, e := range cs.entries {
+		metricPrefixB := appendChurnMetricPrefix(make([]byte, 0, 128), e.labels, e.interval, e.churnInterval, e.filter)
+		metricPrefix := bytesutil.ToUnsafeString(metricPrefixB)
+
+		rate := churnRate(e)
+		buf = buf[:0]
+		if len(e.groupBy) == 0 {
+			buf = append(buf, metricPrefix...)
+			buf = append(buf, `,group_by_keys="__global__"} `...)
+		} else {
+			groupByKeysLabelB := appendGroupByKeysLabel(make([]byte, 0, 128), `group_by_keys`, e.groupBy)
+			groupByKeysLabel := bytesutil.ToUnsafeString(groupByKeysLabelB)
+			buf = appendCardinalityEstimateGroupMetrics(buf, metricPrefix, groupByKeysLabel, e.groupBy, e.values)
+		}
+		buf = strconv.AppendFloat(buf, rate, 'f', 4, 64)
+		buf = append(buf, '\n')
+		if _, err := w.Write(buf); err != nil {
+			return fmt.Errorf("write: %w", err)
+		}
+	}
+	return nil
+}
+
+// churnRate computes the churn rate for a churnEntry.
+// Returns 0 when prev has no data yet.
+func churnRate(e *churnEntry) float64 {
+	psk := e.prev.sketch
+	csk := e.curr.sketch
+	if psk.Estimate() == 0 {
+		return 0
+	}
+	union := csk.Clone()
+	if err := union.Merge(psk); err != nil {
+		return 0
+	}
+	unionEst := union.Estimate()
+	if unionEst == 0 {
+		return 0
+	}
+	churn := float64(2*unionEst) - float64(psk.Estimate()) - float64(csk.Estimate())
+	rate := churn / float64(unionEst)
+	if rate < 0 {
+		return 0
+	}
+	if rate > 1 {
+		return 1
+	}
+	return rate
+}
+
+// appendChurnMetricPrefix produces:
+// 'cardinality_churn_ratio{interval="5m",churn_interval="15m",filter=""'
+func appendChurnMetricPrefix(buf []byte, labels map[string]string, interval, churnInterval time.Duration, filter string) []byte {
+	buf = append(buf, `cardinality_churn_ratio{interval=`...)
+	buf = strconv.AppendQuote(buf, interval.String())
+	buf = append(buf, `,churn_interval=`...)
+	buf = strconv.AppendQuote(buf, churnInterval.String())
+	buf = append(buf, `,filter=`...)
+	buf = strconv.AppendQuote(buf, filter)
+
+	if len(labels) > 0 {
+		keys := make([]string, 0, len(labels))
+		for k := range labels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			buf = append(buf, ',')
+			buf = append(buf, k...)
+			buf = append(buf, '=')
+			buf = strconv.AppendQuote(buf, labels[k])
+		}
+	}
+	return buf
+}

--- a/app/vmestimator/churn.go
+++ b/app/vmestimator/churn.go
@@ -80,11 +80,9 @@ func (cs *churnSnapshots) update(s *snapshot, now time.Time) {
 		}
 
 		if e.curr == nil {
-			// First update: create an empty prev so rotation logic works normally,
-			// but churnRatio will report 0 until prev has real data.
-			empty := ssk.Sketch.Clone()
-			empty.Reset()
-			e.prev = &churnSketch{addedAt: now, sketch: empty}
+			// First update: set prev with a nil sketch so the rotation clock starts
+			// now, but churnRatio returns 0 until the first real rotation.
+			e.prev = &churnSketch{addedAt: now, sketch: nil}
 			e.curr = newSK
 		} else if e.prev.addedAt.Before(now.Add(-s.ChurnInterval)) {
 			e.prev = &churnSketch{addedAt: now, sketch: e.curr.sketch}
@@ -132,13 +130,13 @@ func (cs *churnSnapshots) writeMetrics(w io.Writer) error {
 }
 
 // churnRatio computes the churn rate for a churnEntry.
-// Returns 0 when prev has no data yet.
+// Returns 0 when prev.sketch is nil (synthetic first-update baseline).
 func churnRatio(e *churnEntry) float64 {
-	psk := e.prev.sketch
-	csk := e.curr.sketch
-	if psk.Estimate() == 0 {
+	if e.prev.sketch == nil {
 		return 0
 	}
+	psk := e.prev.sketch
+	csk := e.curr.sketch
 	union := csk.Clone()
 	if err := union.Merge(psk); err != nil {
 		return 0

--- a/app/vmestimator/churn.go
+++ b/app/vmestimator/churn.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/VictoriaMetrics/VictoriaMetrics/lib/bytesutil"
@@ -28,7 +27,7 @@ type churnEntry struct {
 	values        []string // group label values for this groupKey
 
 	prev *churnSketch
-	curr   *churnSketch
+	curr *churnSketch
 }
 
 type churnSketch struct {
@@ -38,9 +37,7 @@ type churnSketch struct {
 
 // churnSnapshots holds prev and curr sketch baselines per (snapshotKey, groupKey).
 // When prev.addedAt < now-churnInterval, prev is reset to curr.
-// Must be accessed under its own mu lock.
 type churnSnapshots struct {
-	mu      sync.Mutex
 	entries map[churnKey]*churnEntry
 }
 
@@ -51,9 +48,6 @@ func newChurnSnapshots() *churnSnapshots {
 // update accepts a single snapshot and upserts one churnEntry per group sketch.
 // Panics if s.ChurnInterval is zero.
 func (cs *churnSnapshots) update(s *snapshot, now time.Time) {
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-
 	if s.ChurnInterval == 0 {
 		logger.Panicf("BUG: update called with snapshot with zero ChurnInterval")
 	}
@@ -104,9 +98,6 @@ func (cs *churnSnapshots) update(s *snapshot, now time.Time) {
 // writeMetrics writes cardinality_churn_rate metrics for all entries.
 // Churn rate is in [0, 1]. Reports 0 when prev has no data yet.
 func (cs *churnSnapshots) writeMetrics(w io.Writer) error {
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-
 	buf := make([]byte, 0, 256)
 	for _, e := range cs.entries {
 		metricPrefixB := appendChurnMetricPrefix(make([]byte, 0, 128), e.labels, e.interval, e.churnInterval, e.filter)

--- a/app/vmestimator/churn_timing_test.go
+++ b/app/vmestimator/churn_timing_test.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+type churnTestGroup struct {
+	key    uint64
+	values []string
+	series []string
+}
+
+func newGlobalChurnSnapshot(churnInterval time.Duration, series ...string) *snapshot {
+	sk := mustNewSketch(14, true)
+	for _, s := range series {
+		sk.Insert([]byte(s))
+	}
+	return &snapshot{
+		Interval:      churnInterval,
+		ChurnInterval: churnInterval,
+		Sketches:      map[uint64]SnapshotSketch{0: {Sketch: sk}},
+	}
+}
+
+func newGroupedChurnSnapshot(churnInterval time.Duration, groupBy []string, groups ...churnTestGroup) *snapshot {
+	s := &snapshot{
+		Interval:      churnInterval,
+		ChurnInterval: churnInterval,
+		GroupBy:       groupBy,
+		Sketches:      make(map[uint64]SnapshotSketch, len(groups)),
+	}
+	for _, g := range groups {
+		sk := mustNewSketch(14, true)
+		for _, series := range g.series {
+			sk.Insert([]byte(series))
+		}
+		s.Sketches[g.key] = SnapshotSketch{Sketch: sk, Values: g.values}
+	}
+	return s
+}
+
+func writeChurnMetrics(t *testing.T, cs *churnSnapshots) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := cs.writeMetrics(&buf); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+func assertChurnMetrics(t *testing.T, act, exp string) {
+	t.Helper()
+	lines := strings.Split(strings.TrimRight(act, "\n"), "\n")
+	sort.Strings(lines)
+	got := strings.Join(lines, "\n")
+	if got != exp {
+		t.Fatalf("unexpected metrics:\ngot:  %s\nwant: %s", got, exp)
+	}
+}
+
+// --- group tests ---
+
+func TestChurnSnapshots_Group_Empty(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cs := newChurnSnapshots()
+		assertChurnMetrics(t, writeChurnMetrics(t, cs), "")
+	})
+}
+
+func TestChurnSnapshots_Group_OneInserted(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cs := newChurnSnapshots()
+		cs.update(newGroupedChurnSnapshot(
+			time.Minute,
+			[]string{"job"},
+			churnTestGroup{
+				key:    1,
+				values: []string{"api"},
+				series: []string{"s1", "s2", "s3"},
+			},
+		), time.Now())
+
+		assertChurnMetrics(
+			t,
+			writeChurnMetrics(t, cs),
+			`cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="job",group_by_values="api",by_job="api"} 0.0000`,
+		)
+	})
+}
+
+func TestChurnSnapshots_Group_TwoInserted_ZeroChurn(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cs := newChurnSnapshots()
+		interval := time.Minute
+		snap := func(series ...string) *snapshot {
+			return newGroupedChurnSnapshot(
+				interval,
+				[]string{"job"},
+				churnTestGroup{key: 1, values: []string{"api"}, series: series},
+			)
+		}
+
+		cs.update(snap("s1", "s2", "s3"), time.Now())
+		time.Sleep(interval + time.Second)
+
+		cs.update(snap("s1", "s2", "s3"), time.Now())
+
+		assertChurnMetrics(
+			t,
+			writeChurnMetrics(t, cs),
+			`cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="job",group_by_values="api",by_job="api"} 0.0000`,
+		)
+	})
+}
+
+func TestChurnSnapshots_Group_TwoInserted_FiftyPercentChurn(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cs := newChurnSnapshots()
+		interval := time.Minute
+		snap := func(series ...string) *snapshot {
+			return newGroupedChurnSnapshot(
+				interval,
+				[]string{"job"},
+				churnTestGroup{key: 1, values: []string{"api"}, series: series},
+			)
+		}
+
+		cs.update(snap("s1", "s2", "s3"), time.Now())
+		time.Sleep(interval + time.Second)
+
+		cs.update(snap("s2", "s3", "s4"), time.Now())
+
+		assertChurnMetrics(
+			t,
+			writeChurnMetrics(t, cs),
+			`cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="job",group_by_values="api",by_job="api"} 0.5000`,
+		)
+	})
+}
+
+func TestChurnSnapshots_Group_TwoInserted_HundredPercentChurn(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cs := newChurnSnapshots()
+		interval := time.Minute
+		snap := func(series ...string) *snapshot {
+			return newGroupedChurnSnapshot(
+				interval,
+				[]string{"job"},
+				churnTestGroup{key: 1, values: []string{"api"}, series: series},
+			)
+		}
+
+		cs.update(snap("s1", "s2", "s3"), time.Now())
+		time.Sleep(interval + time.Second)
+
+		cs.update(snap("s4", "s5", "s6"), time.Now())
+
+		assertChurnMetrics(
+			t,
+			writeChurnMetrics(t, cs),
+			`cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="job",group_by_values="api",by_job="api"} 1.0000`,
+		)
+	})
+}
+
+func TestChurnSnapshots_Group_ThreeInserted_PrevReplaced(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cs := newChurnSnapshots()
+		interval := time.Minute
+		snap := func(series ...string) *snapshot {
+			return newGroupedChurnSnapshot(
+				interval,
+				[]string{"job"},
+				churnTestGroup{key: 1, values: []string{"api"}, series: series},
+			)
+		}
+
+		// First insert: A={s1,s2,s3}. curr=A, prev=empty.
+		cs.update(snap("s1", "s2", "s3"), time.Now())
+		time.Sleep(interval + time.Second)
+
+		// Second insert: B={s4,s5,s6}. prev rotates to A, curr=B. Churn=1 (disjoint).
+		cs.update(snap("s4", "s5", "s6"), time.Now())
+		assertChurnMetrics(
+			t,
+			writeChurnMetrics(t, cs),
+			`cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="job",group_by_values="api",by_job="api"} 1.0000`,
+		)
+		time.Sleep(interval + time.Second)
+
+		// Third insert: C=B={s4,s5,s6}. prev rotates to B, curr=C. Churn=0 (identical).
+		// If prev had NOT rotated (still A), Churn = 1.
+		cs.update(snap("s4", "s5", "s6"), time.Now())
+		assertChurnMetrics(
+			t,
+			writeChurnMetrics(t, cs),
+			`cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="job",group_by_values="api",by_job="api"} 0.0000`,
+		)
+	})
+}
+
+// --- several groups ---
+
+func TestChurnSnapshots_SeveralGroups(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cs := newChurnSnapshots()
+		interval := time.Minute
+		snap := func(apiSeries, workerSeries []string) *snapshot {
+			return newGroupedChurnSnapshot(
+				interval,
+				[]string{"job"},
+				churnTestGroup{key: 1, values: []string{"api"}, series: apiSeries},
+				churnTestGroup{key: 2, values: []string{"worker"}, series: workerSeries},
+			)
+		}
+
+		// A: api={s1,s2,s3}, worker={s1,s2,s3}
+		cs.update(snap([]string{"s1", "s2", "s3"}, []string{"s1", "s2", "s3"}), time.Now())
+		time.Sleep(interval + time.Second)
+
+		// B: api={s1,s2,s3} (no churn), worker={s4,s5,s6} (100% churn)
+		cs.update(snap([]string{"s1", "s2", "s3"}, []string{"s4", "s5", "s6"}), time.Now())
+
+		assertChurnMetrics(
+			t,
+			writeChurnMetrics(t, cs),
+			`cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="job",group_by_values="api",by_job="api"} 0.0000
+cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="job",group_by_values="worker",by_job="worker"} 1.0000`,
+		)
+	})
+}
+
+// --- global ---
+
+func TestChurnSnapshots_Global(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cs := newChurnSnapshots()
+		interval := time.Minute
+
+		cs.update(newGlobalChurnSnapshot(interval, "s1", "s2", "s3"), time.Now())
+		time.Sleep(interval + time.Second)
+
+		cs.update(newGlobalChurnSnapshot(interval, "s2", "s3", "s4"), time.Now())
+
+		assertChurnMetrics(
+			t,
+			writeChurnMetrics(t, cs),
+			`cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="__global__"} 0.5000`,
+		)
+	})
+}

--- a/app/vmestimator/churn_timing_test.go
+++ b/app/vmestimator/churn_timing_test.go
@@ -235,6 +235,32 @@ cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by
 	})
 }
 
+// --- cleanup ---
+
+func TestChurnSnapshots_Cleanup(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cs := newChurnSnapshots()
+		interval := time.Minute
+		expMetric := `cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="__global__"} 0.0000`
+
+		cs.update(newGlobalChurnSnapshot(interval, "s1", "s2"), time.Now())
+
+		// Metric present at start.
+		cs.cleanup(time.Now())
+		assertChurnMetrics(t, writeChurnMetrics(t, cs), expMetric)
+
+		// Metric present just before 2*interval.
+		time.Sleep(2*interval - time.Millisecond)
+		cs.cleanup(time.Now())
+		assertChurnMetrics(t, writeChurnMetrics(t, cs), expMetric)
+
+		// Metric disappears just after 2*interval.
+		time.Sleep(2 * time.Millisecond)
+		cs.cleanup(time.Now())
+		assertChurnMetrics(t, writeChurnMetrics(t, cs), "")
+	})
+}
+
 // --- global ---
 
 func TestChurnSnapshots_Global(t *testing.T) {

--- a/app/vmestimator/churn_timing_test.go
+++ b/app/vmestimator/churn_timing_test.go
@@ -235,6 +235,28 @@ cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by
 	})
 }
 
+// --- real empty prev ---
+
+func TestChurnSnapshots_Global_EmptyPrevWindow_HundredPercentChurn(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cs := newChurnSnapshots()
+		interval := time.Minute
+
+		// First update: empty sketch — no series in the initial window.
+		cs.update(newGlobalChurnSnapshot(interval), time.Now())
+		time.Sleep(interval + time.Second)
+
+		// Rotation: prev = empty (real, not synthetic). Curr gets new series.
+		cs.update(newGlobalChurnSnapshot(interval, "s1", "s2", "s3"), time.Now())
+
+		assertChurnMetrics(
+			t,
+			writeChurnMetrics(t, cs),
+			`cardinality_churn_ratio{interval="1m0s",churn_interval="1m0s",filter="",group_by_keys="__global__"} 1.0000`,
+		)
+	})
+}
+
 // --- cleanup ---
 
 func TestChurnSnapshots_Cleanup(t *testing.T) {

--- a/app/vmestimator/config.go
+++ b/app/vmestimator/config.go
@@ -72,6 +72,7 @@ func loadConfig(path string) ([]*estimator, error) {
 
 	reservedLabels := map[string]bool{
 		"interval":        true,
+		"churn_interval":  true,
 		"filter":          true,
 		"group_by_keys":   true,
 		"group_by_values": true,

--- a/app/vmestimator/config.go
+++ b/app/vmestimator/config.go
@@ -23,7 +23,8 @@ type EstimatorConfig struct {
 	GroupBy      []string          `yaml:"group_by"`
 	GroupLimit   int               `yaml:"group_limit"`
 	Labels       map[string]string `yaml:"labels"`
-	Interval     time.Duration     `yaml:"interval"`
+	Interval      time.Duration `yaml:"interval"`
+	ChurnInterval time.Duration `yaml:"churn_interval"`
 	Buckets      int               `yaml:"buckets"`
 	HLLPrecision uint8             `yaml:"hll_precision"`
 	HLLSparse    *bool             `yaml:"hll_sparse"`

--- a/app/vmestimator/config.go
+++ b/app/vmestimator/config.go
@@ -19,15 +19,15 @@ type Config struct {
 }
 
 type EstimatorConfig struct {
-	Filter       string            `yaml:"filter"`
-	GroupBy      []string          `yaml:"group_by"`
-	GroupLimit   int               `yaml:"group_limit"`
-	Labels       map[string]string `yaml:"labels"`
-	Interval      time.Duration `yaml:"interval"`
-	ChurnInterval time.Duration `yaml:"churn_interval"`
-	Buckets      int               `yaml:"buckets"`
-	HLLPrecision uint8             `yaml:"hll_precision"`
-	HLLSparse    *bool             `yaml:"hll_sparse"`
+	Filter        string            `yaml:"filter"`
+	GroupBy       []string          `yaml:"group_by"`
+	GroupLimit    int               `yaml:"group_limit"`
+	Labels        map[string]string `yaml:"labels"`
+	Interval      time.Duration     `yaml:"interval"`
+	ChurnInterval time.Duration     `yaml:"churn_interval"`
+	Buckets       int               `yaml:"buckets"`
+	HLLPrecision  uint8             `yaml:"hll_precision"`
+	HLLSparse     *bool             `yaml:"hll_sparse"`
 }
 
 func loadConfig(path string) ([]*estimator, error) {

--- a/app/vmestimator/estimator.go
+++ b/app/vmestimator/estimator.go
@@ -54,6 +54,10 @@ func newEstimator(cfg EstimatorConfig) (*estimator, error) {
 		cfg.HLLSparse = new(true)
 	}
 
+	if cfg.ChurnInterval > cfg.Interval {
+		return nil, fmt.Errorf("churn_interval %s must not exceed interval %s", cfg.ChurnInterval, cfg.Interval)
+	}
+
 	if len(cfg.GroupBy) > 5 {
 		return nil, fmt.Errorf("group by must not be bigger than 5 elements; got %d", len(cfg.GroupBy))
 	}
@@ -102,12 +106,13 @@ func newEstimator(cfg EstimatorConfig) (*estimator, error) {
 
 	for i := 0; i < len(e.buckets); i++ {
 		eb := &estimatorBucket{
-			idx:       i,
-			groupSize: e.groupSize,
-			groupBy:   cfg.GroupBy,
-			interval:  cfg.Interval,
-			labels:    cfg.Labels,
-			filter:    cfg.Filter,
+			idx:           i,
+			groupSize:     e.groupSize,
+			groupBy:       cfg.GroupBy,
+			interval:      cfg.Interval,
+			churnInterval: cfg.ChurnInterval,
+			labels:        cfg.Labels,
+			filter:        cfg.Filter,
 
 			precision:       cfg.HLLPrecision,
 			sparse:          *cfg.HLLSparse,
@@ -284,6 +289,7 @@ func (e *estimator) toSnapshot(cb func(s *snapshot) error) error {
 		}
 		s.Sketches[0] = SnapshotSketch{Sketch: resSK}
 		s.Interval = eb0.interval
+		s.ChurnInterval = eb0.churnInterval
 		s.Filter = eb0.filter
 		s.Labels = eb0.labels
 		s.GroupBy = nil
@@ -296,6 +302,7 @@ func (e *estimator) toSnapshot(cb func(s *snapshot) error) error {
 	s.GroupLimit = eb0.groupSize.limit
 	s.GroupBy = eb0.groupBy
 	s.Interval = eb0.interval
+	s.ChurnInterval = eb0.churnInterval
 	s.Filter = eb0.filter
 	s.Labels = eb0.labels
 
@@ -427,6 +434,7 @@ type estimatorBucket struct {
 	idx             int
 	groupBy         []string
 	interval        time.Duration
+	churnInterval   time.Duration
 	filter          string
 	precision       uint8
 	sparse          bool

--- a/app/vmestimator/main.go
+++ b/app/vmestimator/main.go
@@ -156,6 +156,10 @@ func main() {
 			for _, e := range es {
 				e.reset()
 			}
+			cardinalityCacheMu.Lock()
+			globalChurnSnapshots = newChurnSnapshots()
+			cardinalityMetricsCacheAt = time.Time{}
+			cardinalityCacheMu.Unlock()
 			w.WriteHeader(http.StatusOK)
 			return true
 		}

--- a/app/vmestimator/snapshot.go
+++ b/app/vmestimator/snapshot.go
@@ -54,9 +54,10 @@ func (ss *snapshots) writeMetrics(w io.Writer) error {
 }
 
 type snapshot struct {
-	Interval time.Duration
-	Labels   map[string]string
-	Filter   string
+	Interval      time.Duration
+	ChurnInterval time.Duration
+	Labels        map[string]string
+	Filter        string
 
 	GroupBy         []string
 	GroupLimit      int64
@@ -117,6 +118,9 @@ func (s *snapshot) merge(other *snapshot) {
 	}
 
 	s.Interval = other.Interval
+	if other.ChurnInterval > s.ChurnInterval {
+		s.ChurnInterval = other.ChurnInterval
+	}
 	s.Filter = other.Filter
 	for k, v := range other.Labels {
 		if s.Labels == nil {
@@ -288,6 +292,7 @@ func (s *snapshot) reset() {
 	s.GroupLimit = 0
 	s.GroupRejectSize = 0
 	s.Interval = 0
+	s.ChurnInterval = 0
 	s.Filter = ""
 	s.GroupBy = s.GroupBy[:0]
 	clear(s.Labels)

--- a/dashboards/cardinality-estimations.json
+++ b/dashboards/cardinality-estimations.json
@@ -186,10 +186,6 @@
               {
                 "color": "green",
                 "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -608,10 +604,6 @@
               {
                 "color": "green",
                 "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -682,10 +674,10 @@
         "allowCustomValue": false,
         "current": {
           "text": [
-            "monitoring-vmestimator"
+            "All"
           ],
           "value": [
-            "monitoring-vmestimator"
+            "$__all"
           ]
         },
         "datasource": {
@@ -765,8 +757,8 @@
         "allValue": ".*",
         "allowCustomValue": false,
         "current": {
-          "text": "job",
-          "value": "job"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",
@@ -790,10 +782,10 @@
         "allowCustomValue": false,
         "current": {
           "text": [
-            "monitoring-vmsingle"
+            "All"
           ],
           "value": [
-            "monitoring-vmsingle"
+            "$__all"
           ]
         },
         "datasource": {
@@ -817,12 +809,12 @@
     ]
   },
   "time": {
-    "from": "now-12h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "utc",
   "title": "VictoriaMetrics - Cardinality Estimations",
-  "uid": "mktd5g9",
-  "version": 3
+  "uid": "mktd5g9_tmp",
+  "version": 5
 }

--- a/dashboards/cardinality-estimations.json
+++ b/dashboards/cardinality-estimations.json
@@ -815,6 +815,6 @@
   "timepicker": {},
   "timezone": "utc",
   "title": "VictoriaMetrics - Cardinality Estimations",
-  "uid": "mktd5g9_tmp",
+  "uid": "mktd5g9",
   "version": 5
 }

--- a/dashboards/cardinality-estimations.json
+++ b/dashboards/cardinality-estimations.json
@@ -193,7 +193,7 @@
               }
             ]
           },
-          "unit": "percent"
+          "unit": "percentunit"
         },
         "overrides": []
       },
@@ -227,13 +227,13 @@
             "uid": "${ds}"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(\n        max(cardinality_estimate{\n            job=~\"$job\",\n            instance=~\"$instance\",\n            group_by_keys=\"__global__\",\n            interval=\"$churn_long\"\n        }) without (instance)\n    ) by (group_by_keys,group_by_values)\n    -\n    sum(\n        max(cardinality_estimate{\n            job=~\"$job\",\n            instance=~\"$instance\",\n            group_by_keys=\"__global__\",\n            interval=\"$churn_short\"\n        }) without (instance)\n    ) by (group_by_keys,group_by_values)\n)\n/\nsum(\n    max(cardinality_estimate{\n        job=~\"$job\",\n        instance=~\"$instance\",\n        group_by_keys=\"__global__\",\n        interval=\"$churn_long\"\n    }) without (instance)\n) by (group_by_keys,group_by_values)\n* 100",
+          "expr": "max(max_over_time(cardinality_churn_ratio{\n        job=~\"$job\",\n        instance=~\"$instance\",\n        group_by_keys=\"__global__\",\n}[3m])) without (instance, churn_interval)",
           "legendFormat": "{{interval}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Global Churn ($churn_short - $churn_long)",
+      "title": "Global Churn",
       "type": "timeseries"
     },
     {
@@ -615,7 +615,7 @@
               }
             ]
           },
-          "unit": "percent"
+          "unit": "percentunit"
         },
         "overrides": []
       },
@@ -649,13 +649,13 @@
             "uid": "${ds}"
           },
           "editorMode": "code",
-          "expr": "topk(\n    10,\n    (\n        sum(\n            max(cardinality_estimate{\n                job=~\"$job\",\n                instance=~\"$instance\",\n                group_by_keys=~\"$group_by_keys\",\n                group_by_keys!=\"__global__\",\n                group_by_keys!=\"__group__\",\n                group_by_values=~\"$group_by_values\",\n                interval=\"$churn_long\"\n            }) without (instance)\n        ) by (group_by_keys,group_by_values)\n        -\n        sum(\n            max(cardinality_estimate{\n                job=~\"$job\",\n                instance=~\"$instance\",\n                group_by_keys=~\"$group_by_keys\",\n                group_by_keys!=\"__global__\",\n                group_by_keys!=\"__group__\",\n                group_by_values=~\"$group_by_values\",\n                interval=\"$churn_short\"\n            }) without (instance)\n        ) by (group_by_keys,group_by_values)\n    )\n    /\n    sum(\n        max(cardinality_estimate{\n            job=~\"$job\",\n            instance=~\"$instance\",\n            group_by_keys=~\"$group_by_keys\",\n            group_by_keys!=\"__global__\",\n            group_by_keys!=\"__group__\",\n            group_by_values=~\"$group_by_values\",\n            interval=\"$churn_long\"\n        }) without (instance)\n    ) by (group_by_keys,group_by_values) * 100\n)",
+          "expr": "topk(\n    10,\n    max(max_over_time(cardinality_churn_ratio{\n            job=~\"$job\",\n            instance=~\"$instance\",\n            group_by_keys=~\"$group_by_keys\",\n            group_by_keys!=\"__global__\",\n            group_by_keys!=\"__group__\",\n            group_by_values=~\"$group_by_values\"\n    }[15s])) without (instance, churn_interval)\n)",
           "legendFormat": "{{interval}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Top 10 Churn ($churn_short - $churn_long)",
+      "title": "Top 10 Churn",
       "type": "timeseries"
     }
   ],
@@ -681,9 +681,11 @@
         "allValue": ".*",
         "allowCustomValue": false,
         "current": {
-          "text": "All",
+          "text": [
+            "monitoring-vmestimator"
+          ],
           "value": [
-            "$__all"
+            "monitoring-vmestimator"
           ]
         },
         "datasource": {
@@ -763,8 +765,8 @@
         "allValue": ".*",
         "allowCustomValue": false,
         "current": {
-          "text": "All",
-          "value": "$__all"
+          "text": "job",
+          "value": "job"
         },
         "datasource": {
           "type": "prometheus",
@@ -787,9 +789,11 @@
         "allValue": ".*",
         "allowCustomValue": false,
         "current": {
-          "text": "All",
+          "text": [
+            "monitoring-vmsingle"
+          ],
           "value": [
-            "$__all"
+            "monitoring-vmsingle"
           ]
         },
         "datasource": {
@@ -809,59 +813,11 @@
         "refresh": 1,
         "regex": "",
         "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "allowCustomValue": false,
-        "current": {
-          "text": "15m0s",
-          "value": "15m0s"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${ds}"
-        },
-        "definition": "label_values(cardinality_estimate,interval)",
-        "includeAll": false,
-        "name": "churn_short",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(cardinality_estimate,interval)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "allowCustomValue": false,
-        "current": {
-          "text": "30m0s",
-          "value": "30m0s"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${ds}"
-        },
-        "definition": "label_values(cardinality_estimate,interval)",
-        "includeAll": false,
-        "name": "churn_long",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(cardinality_estimate,interval)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {},

--- a/deployment/docker/rules/alerts-cardinality.yml
+++ b/deployment/docker/rules/alerts-cardinality.yml
@@ -22,9 +22,9 @@ groups:
           severity: 'warning'
         annotations:
           dashboard: "{{ $externalURL }}/d/mktd5g9/?viewPanel=panel-7&from={{($activeAt.Add (parseDurationTime \"-1h\")).UnixMilli}}&to={{($activeAt.Add (parseDurationTime \"1h\")).UnixMilli}}"
-          summary: "Global churn rate is more than 10%"
+          summary: "Global churn is more than 10%"
           description: |
-            Global series churn rate is {{ printf "%.0f%%" ($value) }}, exceeding the 10% threshold.
+            Global series churn is {{ printf "%.0f%%" ($value) }}, exceeding the 10% threshold.
             High Churn Rate is tightly connected with database performance and may result in unexpected OOM's or slow queries.
             To investigate, check job or __name__ or other available cardinality estimates, or use the VM cardinality explorer.
 
@@ -36,8 +36,8 @@ groups:
           severity: 'warning'
         annotations:
           dashboard: "{{ $externalURL }}/d/mktd5g9?var-group_by_keys=job&from={{($activeAt.Add (parseDurationTime \"-1h\")).UnixMilli}}&to={{($activeAt.Add (parseDurationTime \"1h\")).UnixMilli}}"
-          summary: "High churn rate for job {{ $labels.group_by_values }}"
-          description: 'Job {{ $labels.group_by_values }} has high series churn rate of {{ printf "%.0f%%" $value }}, exceeding the 20% threshold.'
+          summary: "High churn for job {{ $labels.group_by_values }}"
+          description: 'Job {{ $labels.group_by_values }} has high series churn of {{ printf "%.0f%%" $value }}, exceeding the 20% threshold.'
 
       - alert: 'GlobalCardinalityTooHigh'
         expr: |

--- a/deployment/docker/rules/alerts-cardinality.yml
+++ b/deployment/docker/rules/alerts-cardinality.yml
@@ -5,10 +5,10 @@ groups:
   - name: 'cardinality.recording'
     rules:
       - record: 'cardinality_estimate:weekly_avg'
-        expr: 'avg_over_time((max(cardinality_estimate{group_by_keys=~"__global__|job",interval="30m0s"}) without(instance))[1w:5m])'
+        expr: 'avg_over_time((max(cardinality_estimate{group_by_keys=~"__global__|job",interval="15m0s"}) without(instance))[1w:5m])'
 
       - record: 'cardinality_estimate:weekly_stddev'
-        expr: 'stddev_over_time((max(cardinality_estimate{group_by_keys=~"__global__|job",interval="30m0s"}) without(instance))[1w:5m])'
+        expr: 'stddev_over_time((max(cardinality_estimate{group_by_keys=~"__global__|job",interval="15m0s"}) without(instance))[1w:5m])'
 
   - name: 'cardinality'
     rules:
@@ -16,30 +16,12 @@ groups:
       # See https://github.com/VictoriaMetrics/VictoriaMetrics/blob/master/deployment/docker/rules/alerts-single-node.yml#L88
       - alert: 'GlobalChurnTooHigh'
         expr: |
-          # Detects short-lived series: series present in 30m window but absent in 15m window.
-          # Higher values indicate more short-lived or disappearing series.
-          (
-              max(cardinality_estimate{group_by_keys="__global__",interval="30m0s"}) without (instance)
-              -
-              max(cardinality_estimate{group_by_keys="__global__",interval="15m0s"}) without (instance)
-          )
-          /
-          max(cardinality_estimate{group_by_keys="__global__",interval="30m0s"}) without (instance) * 100 > 10
-          OR
-          # Detects cardinality growth: compares current 15m estimate to the same
-          # estimate 15 minutes ago.
-          (
-              max(cardinality_estimate{group_by_keys="__global__",interval="15m0s"}) without (instance)
-              -
-              max(cardinality_estimate{group_by_keys="__global__",interval="15m0s"} offset 15m) without (instance)
-          )
-          /
-          max(cardinality_estimate{group_by_keys="__global__",interval="15m0s"}) without (instance) * 100 > 10
+          max(max_over_time(cardinality_churn_ratio{group_by_keys="__global__"}[5m])) without (instance) * 100 > 10
         for: '15m'
         labels:
           severity: 'warning'
         annotations:
-          dashboard: "{{ $externalURL }}/d/mktd5g9/?var-churn_short=15m0s&var-churn_long=30m0s&viewPanel=panel-7&from={{($activeAt.Add (parseDurationTime \"-1h\")).UnixMilli}}&to={{($activeAt.Add (parseDurationTime \"1h\")).UnixMilli}}"
+          dashboard: "{{ $externalURL }}/d/mktd5g9/?viewPanel=panel-7&from={{($activeAt.Add (parseDurationTime \"-1h\")).UnixMilli}}&to={{($activeAt.Add (parseDurationTime \"1h\")).UnixMilli}}"
           summary: "Global churn rate is more than 10%"
           description: |
             Global series churn rate is {{ printf "%.0f%%" ($value) }}, exceeding the 10% threshold.
@@ -48,30 +30,12 @@ groups:
 
       - alert: 'JobChurnTooHigh'
         expr: |
-          # Detects short-lived series: series present in 30m window but absent in 15m window.
-          # Higher values indicate more short-lived or disappearing series.
-          (
-              max(cardinality_estimate{group_by_keys="job",interval="30m0s"}) without (instance)
-              -
-              max(cardinality_estimate{group_by_keys="job",interval="15m0s"}) without (instance)
-          )
-          /
-          max(cardinality_estimate{group_by_keys="job",interval="30m0s"}) without (instance) * 100 > 20
-          OR
-          # Detects cardinality growth: compares current 15m estimate to the same
-          # estimate 15 minutes ago.
-          (
-              max(cardinality_estimate{group_by_keys="job",interval="15m0s"}) without (instance)
-              -
-              max(cardinality_estimate{group_by_keys="job",interval="15m0s"} offset 15m) without (instance)
-          )
-          /
-          max(cardinality_estimate{group_by_keys="job",interval="15m0s"}) without (instance) * 100 > 20
+          max(max_over_time(cardinality_churn_ratio{group_by_keys="job"}[5m])) without (instance) * 100 > 20
         for: '30m'
         labels:
           severity: 'warning'
         annotations:
-          dashboard: "{{ $externalURL }}/d/mktd5g9?var-group_by_keys=job&var-churn_short=15m0s&var-churn_long=30m0s&from={{($activeAt.Add (parseDurationTime \"-1h\")).UnixMilli}}&to={{($activeAt.Add (parseDurationTime \"1h\")).UnixMilli}}"
+          dashboard: "{{ $externalURL }}/d/mktd5g9?var-group_by_keys=job&from={{($activeAt.Add (parseDurationTime \"-1h\")).UnixMilli}}&to={{($activeAt.Add (parseDurationTime \"1h\")).UnixMilli}}"
           summary: "High churn rate for job {{ $labels.group_by_values }}"
           description: 'Job {{ $labels.group_by_values }} has high series churn rate of {{ printf "%.0f%%" $value }}, exceeding the 20% threshold.'
 
@@ -81,24 +45,24 @@ groups:
           # mean by more than 3 standard deviations, using the recording rules computed
           # in the cardinality.recording group above.
           (
-            max(cardinality_estimate{group_by_keys="__global__",interval="30m0s"}) without(instance)
+            max(cardinality_estimate{group_by_keys="__global__",interval="15m0s"}) without(instance)
             >
             (
-              cardinality_estimate:weekly_avg{group_by_keys="__global__",interval="30m0s"}
-              + 3 * cardinality_estimate:weekly_stddev{group_by_keys="__global__",interval="30m0s"}
+              cardinality_estimate:weekly_avg{group_by_keys="__global__",interval="15m0s"}
+              + 3 * cardinality_estimate:weekly_stddev{group_by_keys="__global__",interval="15m0s"}
             )
           )
           # Floor condition: ensures the threshold is never too close to the mean — for a perfectly
           # stable baseline where stddev=0, require at least 20% growth before firing.
           AND (
-            max(cardinality_estimate{group_by_keys="__global__",interval="30m0s"}) without(instance)
+            max(cardinality_estimate{group_by_keys="__global__",interval="15m0s"}) without(instance)
             >
-            cardinality_estimate:weekly_avg{group_by_keys="__global__",interval="30m0s"} * 1.2
+            cardinality_estimate:weekly_avg{group_by_keys="__global__",interval="15m0s"} * 1.2
           )
           # Guard: skip when the global historical baseline is too small for 3-sigma to be
           # meaningful — a database with avg 10k series hitting 13k is noise, not an incident.
           # Adjust the threshold to match the typical scale of your environment.
-          AND cardinality_estimate:weekly_avg{group_by_keys="__global__",interval="30m0s"} > 100000
+          AND cardinality_estimate:weekly_avg{group_by_keys="__global__",interval="15m0s"} > 100000
         for: '30m'
         labels:
           severity: 'warning'
@@ -117,23 +81,23 @@ groups:
           # mean by more than 3 standard deviations, using the recording rules computed
           # in the cardinality.recording group above.
           (
-            max(cardinality_estimate{group_by_keys="job",interval="30m0s"}) without(instance)
+            max(cardinality_estimate{group_by_keys="job",interval="15m0s"}) without(instance)
             >
             (
-              cardinality_estimate:weekly_avg{group_by_keys="job",interval="30m0s"}
-              + 3 * cardinality_estimate:weekly_stddev{group_by_keys="job",interval="30m0s"}
+              cardinality_estimate:weekly_avg{group_by_keys="job",interval="15m0s"}
+              + 3 * cardinality_estimate:weekly_stddev{group_by_keys="job",interval="15m0s"}
             )
           )
           AND
           (
-            max(cardinality_estimate{group_by_keys="job",interval="30m0s"}) without(instance)
+            max(cardinality_estimate{group_by_keys="job",interval="15m0s"}) without(instance)
             >
-            cardinality_estimate:weekly_avg{group_by_keys="job",interval="30m0s"} * 1.2
+            cardinality_estimate:weekly_avg{group_by_keys="job",interval="15m0s"} * 1.2
           )
           # Guard: skip jobs whose historical baseline is too small for 3-sigma to be
           # meaningful — a job with avg 5 series hitting 10 is noise, not an incident.
           # Adjust the threshold to match the typical scale of your environment.
-          AND cardinality_estimate:weekly_avg{group_by_keys="job",interval="30m0s"} > 10000
+          AND cardinality_estimate:weekly_avg{group_by_keys="job",interval="15m0s"} > 10000
         for: '30m'
         labels:
           severity: 'warning'

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -16,7 +16,7 @@ Metrics of the latest version of vmestimator cluster are available for viewing a
 
 ## tip
 
-* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add `churn_interval` stream config option. When set, vmestimator emits `cardinality_churn_ratio` metrics measuring how quickly the series set changes within the measurement window. The value is in `[0, 1]`, where `0` means a stable series set and `1` means complete churn. See [churn-calculation](https://docs.victoriametrics.com/victoriametrics/vmestimator/#churn-calculation) and [#24](https://github.com/VictoriaMetrics/vmestimator/issues/24).
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add `churn_interval` stream config option. When set, vmestimator emits `cardinality_churn_ratio` metrics measuring how quickly the series set changes within the measurement window. The ratio is computed as `(2*|A∪B| - |A| - |B|) / |A∪B|` where `A` is the retained HLL snapshot and `B` is the current sketch, resulting in a value in `[0, 1]` where `0` means a stable series set and `1` means complete churn. See [churn-calculation](https://docs.victoriametrics.com/victoriametrics/vmestimator/#churn-calculation) and [#24](https://github.com/VictoriaMetrics/vmestimator/issues/24).
 
 * FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): simplify overflow handling in the deduplicator. Expose `vmestimator_deduplication_passed_total`, `vmestimator_deduplication_dropped_total`, `vmestimator_deduplication_bloom_filter_size`, and `vmestimator_deduplication_bloom_filter_max_size` metrics for monitoring deduplication effectiveness. See [#48](https://github.com/VictoriaMetrics/vmestimator/pull/48).
 

--- a/docs/vmestimator/CHANGELOG.md
+++ b/docs/vmestimator/CHANGELOG.md
@@ -16,6 +16,8 @@ Metrics of the latest version of vmestimator cluster are available for viewing a
 
 ## tip
 
+* FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): add `churn_interval` stream config option. When set, vmestimator emits `cardinality_churn_ratio` metrics measuring how quickly the series set changes within the measurement window. The value is in `[0, 1]`, where `0` means a stable series set and `1` means complete churn. See [churn-calculation](https://docs.victoriametrics.com/victoriametrics/vmestimator/#churn-calculation) and [#24](https://github.com/VictoriaMetrics/vmestimator/issues/24).
+
 * FEATURE: [vmestimator](https://docs.victoriametrics.com/victoriametrics/vmestimator/): simplify overflow handling in the deduplicator. Expose `vmestimator_deduplication_passed_total`, `vmestimator_deduplication_dropped_total`, `vmestimator_deduplication_bloom_filter_size`, and `vmestimator_deduplication_bloom_filter_max_size` metrics for monitoring deduplication effectiveness. See [#48](https://github.com/VictoriaMetrics/vmestimator/pull/48).
 
 ## [v0.1.15](https://github.com/VictoriaMetrics/vmestimator/releases/tag/v0.1.15)

--- a/docs/vmestimator/vmestimator.md
+++ b/docs/vmestimator/vmestimator.md
@@ -323,7 +323,7 @@ Can be narrowed to a specific job: `['job', '__label__']`.
 
 ### Churn calculation
 
-[Churn rate](https://valyala.medium.com/prometheus-storage-technical-terms-for-humans-4ab4de6c3d48#churn-rate) measures how quickly time series are created and disappear.
+[Churn ratio](https://valyala.medium.com/prometheus-storage-technical-terms-for-humans-4ab4de6c3d48#churn-rate) measures how quickly time series are created and disappear.
 [High churn](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-high-churn-rate) means many series appear briefly and are replaced by new ones.
 This puts pressure on storage, because each new series must be indexed regardless of how short its lifetime is.
 

--- a/docs/vmestimator/vmestimator.md
+++ b/docs/vmestimator/vmestimator.md
@@ -119,11 +119,19 @@ streams:
     # Increases are always reflected immediately. Interval only controls how fast the estimate
     # drops after previously seen series disappear.
     #
-    # Running two streams with different intervals (e.g. 5m and 1h) lets you derive churn rate
-    # by comparing their estimates. See Use Cases -> Churn Rate
-    #
     # default: 5m
     interval: <duration>
+
+    # Optional. When set, vmestimator emits a cardinality_churn_ratio metric measuring
+    # how quickly the series set changes within the measurement window.
+    # The look-back comparison window: vmestimator retains a snapshot of the HLL sketch
+    # and replaces it every churn_interval. The churn ratio in [0, 1] is computed as the
+    # Jaccard distance between the current sketch and the retained snapshot.
+    # A ratio of 0 means the series set is completely stable; 1 means completely replaced.
+    # Must not exceed interval.
+    #
+    # default: 0 (churn ratio metric is not emitted)
+    churn_interval: <duration>
 
     # Optional. MetricsQL label selector used to pre-filter time series before counting.
     # Only series matching all matchers are counted. Supports equality (=), negative equality (!=),
@@ -318,42 +326,23 @@ Can be narrowed to a specific job: `['job', '__label__']`.
 [High churn](https://docs.victoriametrics.com/victoriametrics/faq/#what-is-high-churn-rate) means many series appear briefly and are replaced by new ones.
 This puts pressure on storage, because each new series must be indexed regardless of how short its lifetime is.
 
-To measure churn, configure two streams with the same `group_by` but different intervals. A short one (`15m`) and a long one (`30m`):
+To measure churn, add `churn_interval` to a stream:
 
 ```yaml
 # streams.yaml
 
 - interval: '15m'
-  group_by: ['job']
-
-- interval: '30m'
+  churn_interval: '15m'
   group_by: ['job']
 ```
 
-When churn is low, both estimates are roughly equal.
-When churn is high, the `30m` estimate grows significantly larger than the `15m` estimate, because the long window accumulates series that have already disappeared.
-
-The following query computes the churn ratio per job:
+vmestimator will emit a `cardinality_churn_ratio` metric per group. The value is in `[0, 1]`:
+- `0` — the series set is completely stable; the same series were active across both windows.
+- `1` — complete churn; entirely different series appeared in the latest window.
 
 ```
-(
-    sum(
-        max(cardinality_estimate{group_by_keys="job",interval="30m0s"}) without (instance)
-    ) by (group_by_keys,group_by_values)
-    -
-    sum(
-        max(cardinality_estimate{group_by_keys="job",interval="15m0s"}) without (instance)
-    ) by (group_by_keys,group_by_values)
-)
-/
-sum(
-    max(cardinality_estimate{group_by_keys="job",interval="30m0s"}) without (instance)
-) by (group_by_keys,group_by_values) * 100
+cardinality_churn_ratio{interval="15m0s",churn_interval="15m0s",filter="",group_by_keys="job",group_by_values="api",by_job="api"} 0.1200
 ```
-
-A result near `0` means the series set is stable. The same series were active throughout the entire hour.
-A result near `1` means complete churn. Entirely different series appeared each 5-minute window.
-Values in between indicate the fraction of maximum possible churn that is occurring.
 
 This helps identify jobs that create the most indexing pressure on storage, even when their current active cardinality appears moderate.
 
@@ -362,7 +351,7 @@ This helps identify jobs that create the most indexing pressure on storage, even
 Pre-built alert rules for cardinality monitoring are available in
 [deployment/docker/rules/alerts-cardinality.yml](https://github.com/VictoriaMetrics/vmestimator/blob/main/deployment/docker/rules/alerts-cardinality.yml).
 
-They require two streams with the same `group_by` but different intervals to also support churn detection:
+They require the following stream configuration to also support churn detection:
 
 ```yaml
 # streams.yaml
@@ -370,18 +359,16 @@ They require two streams with the same `group_by` but different intervals to als
 # https://github.com/VictoriaMetrics/vmestimator/blob/main/streams.yaml
 
 - interval: '15m'
-  group_by: ['job']
-
-- interval: '30m'
+  churn_interval: '15m'
   group_by: ['job']
 ```
 
 The included alerts are:
 
-- **JobTooHighCardinality** — fires when any job exceeds 20,000 estimated active series over the last 30 minutes.
+- **JobTooHighCardinality** — fires when any job exceeds 20,000 estimated active series over the last 15 minutes.
   The threshold is a starting point and should be calibrated to reflect the expected cardinality of your largest jobs.
 
-- **JobTooHighChurnRate** — fires when more than 10% of a job's series churned between the 15m and 30m windows.
+- **JobTooHighChurnRate** — fires when more than 20% of a job's series churned in the last `churn_interval` window.
   Catches jobs that generate continuous indexing pressure even when their active series count looks moderate.
 
 - **CardinalityGroupLimitNearlyReached** — fires when the number of tracked groups exceeds 80% of the configured `group_limit`.

--- a/docs/vmestimator/vmestimator.md
+++ b/docs/vmestimator/vmestimator.md
@@ -125,8 +125,9 @@ streams:
     # Optional. When set, vmestimator emits a cardinality_churn_ratio metric measuring
     # how quickly the series set changes within the measurement window.
     # The look-back comparison window: vmestimator retains a snapshot of the HLL sketch
-    # and replaces it every churn_interval. The churn ratio in [0, 1] is computed as the
-    # Jaccard distance between the current sketch and the retained snapshot.
+    # and replaces it every churn_interval. The churn ratio in [0, 1] is computed as:
+    #   (2*|A∪B| - |A| - |B|) / |A∪B|
+    # where A is the retained snapshot and B is the current sketch.
     # A ratio of 0 means the series set is completely stable; 1 means completely replaced.
     # Must not exceed interval.
     #

--- a/docs/vmestimator/vmestimator.md
+++ b/docs/vmestimator/vmestimator.md
@@ -359,6 +359,11 @@ They require the following stream configuration to also support churn detection:
 # or use example config:
 # https://github.com/VictoriaMetrics/vmestimator/blob/main/streams.yaml
 
+# Global stream — required for GlobalChurnTooHigh and GlobalCardinalityTooHigh.
+- interval: '15m'
+  churn_interval: '15m'
+
+# Per-job stream — required for JobChurnTooHigh and JobCardinalityTooHigh.
 - interval: '15m'
   churn_interval: '15m'
   group_by: ['job']

--- a/docs/vmestimator/vmestimator.md
+++ b/docs/vmestimator/vmestimator.md
@@ -366,11 +366,18 @@ They require the following stream configuration to also support churn detection:
 
 The included alerts are:
 
-- **JobTooHighCardinality** — fires when any job exceeds 20,000 estimated active series over the last 15 minutes.
-  The threshold is a starting point and should be calibrated to reflect the expected cardinality of your largest jobs.
+- **GlobalChurnTooHigh** — fires when global series churn exceeds 10% for 15 minutes.
+  High global churn can cause unexpected OOM or slow queries across the whole database.
 
-- **JobTooHighChurnRate** — fires when more than 20% of a job's series churned in the last `churn_interval` window.
+- **JobChurnTooHigh** — fires when more than 20% of a job's series churned for 30 minutes.
   Catches jobs that generate continuous indexing pressure even when their active series count looks moderate.
+
+- **GlobalCardinalityTooHigh** — fires when global cardinality exceeds the weekly mean by more than 3 standard deviations
+  and has grown at least 20% above that mean, sustained for 30 minutes. The guard baseline is 100,000 series.
+
+- **JobCardinalityTooHigh** — fires when a job's cardinality exceeds its weekly mean by more than 3 standard deviations
+  and has grown at least 20% above that mean, sustained for 30 minutes. The guard baseline is 10,000 series per job.
+  Uses 3-sigma anomaly detection rather than a fixed threshold, so it adapts to the expected scale of each job.
 
 - **CardinalityGroupLimitNearlyReached** — fires when the number of tracked groups exceeds 80% of the configured `group_limit`.
   Acts as an early warning that some label value combinations may soon be dropped from individual tracking.

--- a/streams.yaml
+++ b/streams.yaml
@@ -1,13 +1,11 @@
 streams:
   - interval: '15m'
-  - interval: '30m'
+    churn_interval: '15m'
 
   - interval: '15m'
-    group_by: ["__name__"]
-  - interval: '30m'
+    churn_interval: '15m'
     group_by: ["__name__"]
 
   - interval: '15m'
-    group_by: ["job"]
-  - interval: '30m'
+    churn_interval: '15m'
     group_by: ["job"]


### PR DESCRIPTION
When `churn_interval` is set, vmestimator emits `cardinality_churn_ratio` metrics measuring how quickly the series set changes within the measurement window.

The ratio is computed as `(2*|AuB| - |A| - |B|) / |AuB|`, where A is a retained HLL snapshot and B is the current sketch, resulting in a value in [0, 1].

Update alerts\dashboards to use `cardinality_churn_ratio` instead of two-stream arithmetic.

Fixes https://github.com/VictoriaMetrics/vmestimator/issues/24
